### PR TITLE
fix(calendar): show bookings that go until midnight

### DIFF
--- a/frontend/app/room/[room]/page.tsx
+++ b/frontend/app/room/[room]/page.tsx
@@ -1,19 +1,18 @@
-"use client" 
+"use client";
 
 import translateRoomUsage from "@common/roomUsages";
 import getSchoolDetails from "@common/schools";
-import type { Room } from "@common/types";
+import type { Booking, Room } from "@common/types";
 import CloseIcon from "@mui/icons-material/Close";
-import  {Dialog, DialogContent, DialogContentText, DialogTitle, IconButton} from '@mui/material';
-import Box from '@mui/material/Box';
+import { Dialog, DialogContent, DialogContentText, DialogTitle, IconButton } from "@mui/material";
+import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
-import Link from '@mui/material/Link';
-import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
-import useBuilding from 'hooks/useBuilding';
+import Link from "@mui/material/Link";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import useBuilding from "hooks/useBuilding";
 import Image from "next/image";
-import React from 'react';
-import { useState } from 'react';
+import React, { useState } from "react";
 
 import BookingCalendar from "../../../components/BookingCalendar";
 import Button from "../../../components/Button";
@@ -21,140 +20,172 @@ import LoadingCircle from "../../../components/LoadingCircle";
 import useBookings from "../../../hooks/useBookings";
 import useRoom from "../../../hooks/useRoom";
 
+const adjustDateIfMidnight = (inputDate: Date): Date => {
+  // Check if the time is midnight (00:00:00)
+  if (inputDate.getHours() === 0 && inputDate.getMinutes() === 0 && inputDate.getSeconds() === 0) {
+    // Set the time to 11:59:00 and subtract one day
+    const adjusted = new Date(inputDate);
+    adjusted.setHours(23, 59);
+    adjusted.setDate(inputDate.getDate() - 1);
+    return adjusted;
+  } else {
+    return inputDate;
+  }
+};
+
 
 export default function Page({ params }: {
-  params: {room: string}; }) {
-	const { bookings } = useBookings(params.room);
-	const { room } = useRoom(params.room);
-    const [ campus, grid ] = room ? room.id.split('-') : [ "", "" ];
-    const { building } = useBuilding(`${campus}-${grid}`);
+  params: { room: string };
+}) {
+  const { bookings } = useBookings(params.room);
+  const adjustedBookings: Booking[] | undefined = bookings?.map(booking => ({
+    ...booking,
+    end: adjustDateIfMidnight(booking.end),
+  }));
 
-    return (
-        <Container maxWidth={'xl'}>
-            { room != undefined ? 
-                ( 
-                <Stack justifyContent="center" alignItems="center" width="100%" py={5} height="100%" px={{ xs: 3, md: 15 }}>
-                    <RoomPageHeader room={room} buildingName={ building != undefined ? building.name : "" } />
-                    <RoomImage src={`/assets/building_photos/${campus}-${grid}.webp`} /> 
-                    <BookingCalendar events={ bookings == undefined ? [] : bookings } />
-                </Stack>
-                ) : <LoadingCircle />  }
-        </Container>
+  const { room } = useRoom(params.room);
+  const [campus, grid] = room ? room.id.split("-") : ["", ""];
+  const { building } = useBuilding(`${campus}-${grid}`);
+
+  return (
+    <Container maxWidth="xl">
+      {room && building ?
+        (
+          <Stack justifyContent="center" alignItems="center" width="100%" py={5} height="100%" px={{ xs: 3, md: 15 }}>
+            <RoomPageHeader room={room} buildingName={building.name} />
+            <RoomImage src={`/assets/building_photos/${campus}-${grid}.webp`} />
+            <BookingCalendar events={adjustedBookings ?? []} />
+          </Stack>
+        ) : <LoadingCircle />}
+    </Container>
   );
 }
 
-const RoomPageHeader : React.FC<{ room : Room, buildingName: string }> = ({
-    room, 
-    buildingName
+const RoomPageHeader: React.FC<{ room: Room, buildingName: string }> = ({
+  room,
+  buildingName,
 }) => {
 
-    const [ openDialog, setDialog ] = useState(false);
-    const toggleDialog = () => {
-        setDialog( (isOpen) => { return !isOpen } ); 
-    }
+  const [openDialog, setDialog] = useState(false);
+  const toggleDialog = () => {
+    setDialog((isOpen) => {
+      return !isOpen;
+    });
+  };
 
-    const schoolDetails = getSchoolDetails(room.school);
-	const dialogMessage = schoolDetails ? ( 
-		`This room is managed by ${schoolDetails.name}. Please contact the school to request a booking` 
-		) : "This room is managed externally by its associated school. Please contact the school to request a booking"
+  const schoolDetails = getSchoolDetails(room.school);
+  const dialogMessage = schoolDetails ? (
+    `This room is managed by ${schoolDetails.name}. Please contact the school to request a booking`
+  ) : "This room is managed externally by its associated school. Please contact the school to request a booking";
 
-    return (
-		<Box
-			width={"100%"}
-			display={"flex"}
-			flexDirection={"row"}
-			alignItems={'center'}
-			justifyContent={"space-between"}
-		>
-			<Stack direction={"column"} spacing={1} width="100%" mb={1}>
-				{buildingName != "" && (
-					<Stack direction='row' spacing={2} >
-						<Typography display="inline" variant="subtitle2">{`${buildingName}`} </Typography>
-						<Typography display="inline" variant="subtitle2">{"/"}</Typography>
-						<Typography display="inline" variant="subtitle2">{`${translateRoomUsage(room.usage)}`}</Typography>
-						{ room.school != " " ? <Typography display="inline" variant="subtitle2">{"/"}</Typography> : null }
-						{ room.school != " " ? <Typography display="inline" fontWeight={"bold"} color={"#e65100"} variant="subtitle2">{"ID Required"}</Typography> : null }
-					</Stack>
-				)}
-				<Box display="flex" justifyContent={"space-between"} alignItems={'center'} width={'100%'} >
-					<Typography variant='h4' fontWeight={550}> {room.name} </Typography>
-					<BookingButton school={room.school} usage={room.usage} onClick={toggleDialog} />
-				</Box>
-				<Stack direction={"row"} spacing={2}  >
-					<Typography variant="body1" fontWeight={"bold"}>
-						ID: <Typography display={"inline"} variant="body1">{room.id}</Typography>
-					</Typography>
-                    <Typography variant="body1" fontWeight={"bold"}>
-						Capacity: <Typography display={"inline"} variant="body1">{room.capacity}</Typography>
-					</Typography>
-                    <Typography variant="body1" fontWeight={"bold"}>
-						Abbreviation: <Typography display={"inline"} variant="body1">{room.abbr}</Typography>
-					</Typography>
+  return (
+    <Stack width="100%" direction="row" alignItems="center" justifyContent="space-between">
+      <Stack direction="column" spacing={1} width="100%" mb={1}>
+        {buildingName != "" && (
+          <Stack
+            direction="row"
+            spacing={2}
+            divider={<Typography display="inline" variant="subtitle2">/</Typography>}
+          >
+            <Typography variant="subtitle2">{buildingName} </Typography>
+            <Typography variant="subtitle2">{translateRoomUsage(room.usage)}</Typography>
+            {room.school != " " && (
+              <Typography fontWeight="bold" color="#e65100" variant="subtitle2">
+                ID Required
+              </Typography>
+            )}
+          </Stack>
+        )}
+        <Stack direction="row" justifyContent="space-between" alignItems="center" width="100%">
+          <Typography variant="h4" fontWeight={550}> {room.name} </Typography>
+          <BookingButton school={room.school} usage={room.usage} onClick={toggleDialog} />
+        </Stack>
+        <Stack direction="row" spacing={2}>
+          <Typography variant="body1" fontWeight="bold">
+            ID: {room.id}
+          </Typography>
+          <Typography variant="body1" fontWeight="bold">
+            Capacity: {room.capacity}
+          </Typography>
+          <Typography variant="body1" fontWeight="bold">
+            Abbreviation: {room.abbr}
+          </Typography>
 
-					{room.school != " " && (
-					  <Typography variant="body1" fontWeight={"bold"}>
-							School: <Typography display={"inline"} variant="body1">{ schoolDetails ? schoolDetails.name : room.school }</Typography>
-						</Typography>
-					)}
-				</Stack>
-			</Stack>
-			<Dialog open={openDialog} onClose={toggleDialog} PaperProps={{ sx: { borderRadius: '10px' }}}>
-				<DialogTitle>
-					<Typography variant={"h6"} fontWeight={"Bold"}>Booking this Room</Typography>
-				</DialogTitle>
-				<IconButton
-					aria-label="close"
-					onClick={() => setDialog(false)}
-					sx={{
-						position: 'absolute',
-						right: 12,
-						top: 12,
-						color: (theme) => theme.palette.grey[500],
-					}}
-				>
-					<CloseIcon />
-				</IconButton>
-				<DialogContent dividers>
-					<DialogContentText>
-						<Stack direction={"column"} spacing={2}>
-							<Typography variant={"body1"}>
-								{ dialogMessage }
-							</Typography>
-							{ schoolDetails ? <Typography variant={"body1"}> You can find the contact details of the school <Link target="_blank" href={schoolDetails.contactLink}>here</Link>. </Typography> : null }
-						</Stack>
-					</DialogContentText>
-				</DialogContent>
-			</Dialog>
-		</Box>
+          {room.school != " " && (
+            <Typography variant="body1" fontWeight="bold">
+              School: <Typography
+              display="inline"
+              variant="body1"
+            >{schoolDetails ? schoolDetails.name : room.school}</Typography>
+            </Typography>
+          )}
+        </Stack>
+      </Stack>
+      <Dialog open={openDialog} onClose={toggleDialog} PaperProps={{ sx: { borderRadius: "10px" } }}>
+        <DialogTitle>
+          <Typography variant="h6" fontWeight="Bold">Booking this Room</Typography>
+        </DialogTitle>
+        <IconButton
+          aria-label="close"
+          onClick={() => setDialog(false)}
+          sx={{
+            position: "absolute",
+            right: 12,
+            top: 12,
+            color: (theme) => theme.palette.grey[500],
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
+        <DialogContent dividers>
+          <DialogContentText>
+            <Stack direction="column" spacing={2}>
+              <Typography variant="body1">
+                {dialogMessage}
+              </Typography>
+              {schoolDetails && (
+                <Typography variant="body1">
+                  You can find the contact details of the school <Link target="_blank" href={schoolDetails.contactLink}>here</Link>.
+                </Typography>
+              )}
+            </Stack>
+          </DialogContentText>
+        </DialogContent>
+      </Dialog>
+    </Stack>
 
-	);
-}
+  );
+};
 
-const BookingButton : React.FC<{ school: string, usage: string, onClick : () => void }> = ({ school, usage, onClick }) => {
+const BookingButton: React.FC<{ school: string, usage: string, onClick: () => void }> = ({
+  school,
+  usage,
+  onClick,
+}) => {
 
-    let link = "";
-    if( school === " " && usage === "LIB" ) link = "https://unswlibrary-bookings.libcal.com";
-    else if( school === " " ) link = "https://www.learningenvironments.unsw.edu.au/make-booking/book-room";
+  let link = "";
+  if (school === " " && usage === "LIB") link = "https://unswlibrary-bookings.libcal.com";
+  else if (school === " ") link = "https://www.learningenvironments.unsw.edu.au/make-booking/book-room";
 
-    if (link != "") return (
-			<Link target="_blank" href={link}>
-				<Button  sx={{ px: 2, py: 1, height: 45 }} >
-					<Typography variant={"body2"} fontWeight={"bold"}>Make a Booking</Typography>
-				</Button>
-			</Link>
-    );
+  if (link) return (
+    <Link target="_blank" href={link}>
+      <Button sx={{ px: 2, py: 1, height: 45 }}>
+        <Typography variant="body2" fontWeight="bold">Make a Booking</Typography>
+      </Button>
+    </Link>
+  );
 
-    return (
-			<Button onClick={onClick} sx={{ px: 2, py: 1, height: 45 }}>
-				<Typography variant={"body2"} fontWeight={"bold"}>Make a Booking</Typography>
-			</Button>
-    );
-}
+  return (
+    <Button onClick={onClick} sx={{ px: 2, py: 1, height: 45 }}>
+      <Typography variant="body2" fontWeight="bold">Make a Booking</Typography>
+    </Button>
+  );
+};
 
-const RoomImage : React.FC<{ src : string }> = ({ src }) => {
-	return (
-	    <Box minWidth={"100%"} minHeight={300} position="relative" >
-	        <Image src={src} alt={"Room Image"} fill style={{ objectFit: "cover", borderRadius: 10 }}/>	
-		</Box>
-	);
-}
+const RoomImage: React.FC<{ src: string }> = ({ src }) => {
+  return (
+    <Box minWidth="100%" minHeight={300} position="relative">
+      <Image src={src} alt="Room Image" fill style={{ objectFit: "cover", borderRadius: 10 }} />
+    </Box>
+  );
+};

--- a/frontend/components/BookingCalendar.tsx
+++ b/frontend/components/BookingCalendar.tsx
@@ -183,13 +183,11 @@ const BookingCalendar : React.FC<{ events : Array<Booking> }>= ({ events }) => {
 		culture: string | undefined,
 		localizer?: DateLocalizer
 	) => {
-		console.log({start, end});
 		return formatTime(start, culture, localizer) + " - " + formatTime(end, culture, localizer);
 	}
 
 	// Only render booking type on day view (wide)
 	const titleAccessor = React.useCallback((booking: Booking): string => {
-		console.log(booking);
 		if (currView == Views.DAY) {
 			return `${booking.name} (${booking.bookingType})`;
 		} else {

--- a/frontend/components/BookingCalendar.tsx
+++ b/frontend/components/BookingCalendar.tsx
@@ -172,7 +172,7 @@ const BookingCalendar : React.FC<{ events : Array<Booking> }>= ({ events }) => {
 		}
 		let res = localizer.format(date, "h", culture);
 		if (date.getMinutes() !== 0) {
-			res += localizer.format(date, ":m", culture);
+			res += localizer.format(date, ":mm", culture);
 		}
 		res += localizer.format(date, " a", culture);
 		return res;
@@ -183,11 +183,13 @@ const BookingCalendar : React.FC<{ events : Array<Booking> }>= ({ events }) => {
 		culture: string | undefined,
 		localizer?: DateLocalizer
 	) => {
+		console.log({start, end});
 		return formatTime(start, culture, localizer) + " - " + formatTime(end, culture, localizer);
 	}
 
 	// Only render booking type on day view (wide)
 	const titleAccessor = React.useCallback((booking: Booking): string => {
+		console.log(booking);
 		if (currView == Views.DAY) {
 			return `${booking.name} (${booking.bookingType})`;
 		} else {
@@ -242,8 +244,7 @@ const BookingCalendar : React.FC<{ events : Array<Booking> }>= ({ events }) => {
 						slotGroupPropGetter={() => ({ style: { minHeight: "50px" }})}
 						dayPropGetter={(date) => ({ style: { backgroundColor: isToday(date) ? "#fff3e0" : "white" }})}
 						min={new Date(0, 0, 0, 9)}
-						max={new Date(0, 0, 0, 22)}
-						showMultiDayTimes={false}
+						showMultiDayTimes={true}
 						formats={{
 							timeGutterFormat: formatTime,
 							eventTimeRangeFormat: formatTimeRange


### PR DESCRIPTION
With the addition of the law library on Freerooms recently, there are a number of bookings that end at midnight because law students are insane. Currently these are being hidden because `showMultiDayTimes` prop of the calendar component was set to `false`, and since midnight technically means it goes to the next day, it hides these bookings.

Turning `showMultiDayTimes` to `true` creates some weird behaviour where an event is displayed on the first day that says e.g. "6PM -" and then another event on the next day that says "- 12AM". This looks really weird, so I've decided to instead change any bookings that end at 12AM to end at 11:59PM (this is just on the frontend). I've also left `showMultiDayTimes` as `true`, in case there's a booking that goes overnight to not 12AM. It still looks weird, but better that then hidden.

Also I reformatted the room page file because holy shit that file was a mess. Like, there was inconsistent indentation and random spaces everywhere.