### PR TITLE
fix(status): account for bookings past midnight in status

### DIFF
--- a/backend/src/dbInterface.ts
+++ b/backend/src/dbInterface.ts
@@ -43,13 +43,12 @@ export const queryBookingsInRange = async (
   start: Date,
   end: Date,
 ): Promise<BookingsInRangeRes> => {
-  // alternative condition: (where: {start: {_lte: $end}, end: {_gte: $start}})
   const query = `
     query BookingsInRange($start: timestamptz, $end: timestamptz) {
       rooms {
         id
         name
-        bookings(where: {start: {_gte: $start, _lte: $end}, end: {_gte: $start, _lte: $end}}, order_by: {start: asc}) {
+        bookings(where: {start: {_lte: $end}, end: {_gte: $start}}, order_by: {start: asc}) {
           name
           bookingType
           start


### PR DESCRIPTION
Similar issue to #419

Currently, room status is calculate by fetching all bookings that **start and end** between 00:00 and 23:59 of the queried day. Importantly, bookings that go until midnight or past midnight are not fetched. This means a room busy all day until midnight appears to have no bookings and is shown as free - a lot of law library rooms are like this and appear free.

This PR fixes that by fetching all bookings that **overlap** with the fetched day instead. So, we will also get bookings that:
- Start before 23:59 but end on the next day
- Started the previous day but end on the current day

This means the midnight bookings are accounted for. The query is also slightly slower now (100ms -> 200ms) but oh well.