### PR TITLE
doc: update README to use npm instead of pnpm

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -4,12 +4,12 @@ The Freerooms backend is an Express.js server.
 
 ## Installation Guide
 
-The package manager used is [pnpm](https://pnpm.io/), you will need to install it if you haven't already.
+The package manager used is [npm](https://www.npmjs.com/), which should already be there if you've installed Node.
 
 Once installed, you can run the following command to install dependencies:
 
 ```bash
-pnpm install
+npm install
 ```
 
 ## Usage Guide
@@ -17,7 +17,7 @@ pnpm install
 You can run the backend with the following command:
 
 ```bash
-pnpm start
+npm start
 ```
 
 To check things are working properly, you can send a request to [http://localhost:3000/api/buildings](http://localhost:3000/api/buildings).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,12 +4,12 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Installation Guide
 
-The package manager used is [pnpm](https://pnpm.io/), you will need to install it if you haven't already.
+The package manager used is [npm](https://www.npmjs.com/), which should already be there if you've installed Node.
 
 Once installed, you can run the following command to install dependencies:
 
 ```bash
-pnpm install
+npm install
 ```
 
 ## Usage Guide
@@ -19,7 +19,13 @@ Before running the frontend, you must **first** run [the backend](../backend).
 You can run the frontend with the following command:
 
 ```bash
-pnpm start
+npm start
+```
+
+During development, you should run the frontend in dev mode instead:
+
+```bash
+npm run dev
 ```
 
 Open [http://localhost:3001](http://localhost:3001) with your browser to see the result.


### PR DESCRIPTION
Previously, freerooms used `pnpm` as the package manager. Since we have now moved to using `npm` in [this PR](https://github.com/devsoc-unsw/freerooms/pull/429), adjusted the install and run instructions in README files for both backend and frontend accordingly.