### PR TITLE
458 - reduced spacing between features and FAQ on landing page

### DIFF
--- a/frontend/__tests__/Features.test.tsx
+++ b/frontend/__tests__/Features.test.tsx
@@ -1,0 +1,44 @@
+import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+
+import Features from "../components/Features";
+
+jest.mock("react-redux", () => ({
+  ...jest.requireActual("react-redux"),
+  useDispatch: jest.fn(),
+}));
+
+describe("Features", () => {
+  it("renders heading text", () => {
+    render(<Features />);
+
+    const heading = screen.getByText("Our Features");
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it("shows BrowseBuildings icon", () => {
+    render(<Features />);
+
+    const BrowseBuildings = screen.getByText("Browse Buildings");
+
+    expect(BrowseBuildings).toBeInTheDocument();
+  });
+
+  it("shows map icon", () => {
+    render(<Features />);
+
+    const Map = screen.getByText("Map");
+
+    expect(Map).toBeInTheDocument();
+  });
+
+  it("shows Timetable icon", () => {
+    render(<Features />);
+
+    const Timetable = screen.getByText("Timetable");
+
+    expect(Timetable).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/Features.test.tsx
+++ b/frontend/__tests__/Features.test.tsx
@@ -21,24 +21,24 @@ describe("Features", () => {
   it("shows BrowseBuildings icon", () => {
     render(<Features />);
 
-    const BrowseBuildings = screen.getByText("Browse Buildings");
+    const browseBuildings = screen.getByText("Browse Buildings");
 
-    expect(BrowseBuildings).toBeInTheDocument();
+    expect(browseBuildings).toBeInTheDocument();
   });
 
   it("shows map icon", () => {
     render(<Features />);
 
-    const Map = screen.getByText("Map");
+    const map = screen.getByText("Map");
 
-    expect(Map).toBeInTheDocument();
+    expect(map).toBeInTheDocument();
   });
 
   it("shows Timetable icon", () => {
     render(<Features />);
 
-    const Timetable = screen.getByText("Timetable");
+    const timetable = screen.getByText("Timetable");
 
-    expect(Timetable).toBeInTheDocument();
+    expect(timetable).toBeInTheDocument();
   });
 });

--- a/frontend/app/room/[room]/page.tsx
+++ b/frontend/app/room/[room]/page.tsx
@@ -92,6 +92,10 @@ const RoomPageHeader: React.FC<{ room: Room; buildingName: string }> = ({
     ? `This room is managed by ${schoolDetails.name}. Please contact the school to request a booking`
     : "This room is managed externally by its associated school. Please contact the school to request a booking";
 
+  // const handleBackClick = () => {
+  //   dispatch(setCurrentBuilding(building))
+  // };
+
   return (
     <Stack
       width="100%"
@@ -121,6 +125,15 @@ const RoomPageHeader: React.FC<{ room: Room; buildingName: string }> = ({
             )}
           </Stack>
         )}
+        {/* <IconButton
+        href="/browse"
+          onClick={handleBackClick}
+          style={{ width: "5%", color: "black" }}
+        >
+          <ArrowBack />
+          <Typography variant="body1">Back</Typography>
+        </IconButton> */}
+
         <Stack
           direction="row"
           justifyContent="space-between"

--- a/frontend/app/room/[room]/page.tsx
+++ b/frontend/app/room/[room]/page.tsx
@@ -92,10 +92,6 @@ const RoomPageHeader: React.FC<{ room: Room; buildingName: string }> = ({
     ? `This room is managed by ${schoolDetails.name}. Please contact the school to request a booking`
     : "This room is managed externally by its associated school. Please contact the school to request a booking";
 
-  // const handleBackClick = () => {
-  //   dispatch(setCurrentBuilding(building))
-  // };
-
   return (
     <Stack
       width="100%"
@@ -125,14 +121,6 @@ const RoomPageHeader: React.FC<{ room: Room; buildingName: string }> = ({
             )}
           </Stack>
         )}
-        {/* <IconButton
-        href="/browse"
-          onClick={handleBackClick}
-          style={{ width: "5%", color: "black" }}
-        >
-          <ArrowBack />
-          <Typography variant="body1">Back</Typography>
-        </IconButton> */}
 
         <Stack
           direction="row"

--- a/frontend/components/Faq.tsx
+++ b/frontend/components/Faq.tsx
@@ -150,9 +150,14 @@ const StyledHeaderDiv = styled("div")(({ theme }) => ({
 }));
 
 const StyledParentDiv = styled("div")(({ theme }) => ({
-  display: "flex",
-  justifyContent: "center",
-  flexDirection: "column",
-  width: "100%",
   alignItems: "center",
+  bottom: "150px",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  position: "relative",
+  width: "100%",
+  [theme.breakpoints.down("lg")]: {
+    bottom: "0",
+  },
 }));

--- a/frontend/components/FeatureCard.tsx
+++ b/frontend/components/FeatureCard.tsx
@@ -19,7 +19,7 @@ const StyledParentDiv = styled("div")(({ theme }) => ({
   width: "19rem",
   transition: "transform 0.3s",
   cursor: "pointer",
-  margin: "1rem 0",
+  margin: "1rem 0.5rem",
   [theme.breakpoints.down("lg")]: {
     boxShadow:
       "0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)",

--- a/frontend/components/Features.tsx
+++ b/frontend/components/Features.tsx
@@ -23,6 +23,7 @@ const Features = () => {
         />
         <StyledHeading>Our Features</StyledHeading>
       </div>
+
       <Box
         mt={10}
         width="100%"
@@ -69,6 +70,7 @@ export default Features;
 const StyledHeading = styled("h2")(({ theme }) => ({
   textAlign: "center",
   fontSize: "3rem",
+  paddingBottom: "50%",
 }));
 
 const StyledFeatureVector = styled(Image)(({ theme }) => ({
@@ -104,6 +106,8 @@ const StyledBackgroudVector = styled(Image)(({ theme }) => ({
 }));
 
 const StyledCardParent = styled("div")(({ theme }) => ({
+  marginTop: "0%",
+  paddingBottom: "0%",
   position: "absolute",
   display: "flex",
   flexDirection: "row",
@@ -115,5 +119,15 @@ const StyledCardParent = styled("div")(({ theme }) => ({
   [theme.breakpoints.down("lg")]: {
     flexDirection: "column",
     alignItems: "center",
+    marginTop: "25%",
+    paddingBottom: "25%",
+  },
+  [theme.breakpoints.down("md")]: {
+    marginTop: "20%",
+    paddingBottom: "15%",
+  },
+  [theme.breakpoints.down("sm")]: {
+    marginTop: "35%",
+    paddingBottom: "10%",
   },
 }));

--- a/frontend/components/Features.tsx
+++ b/frontend/components/Features.tsx
@@ -26,7 +26,7 @@ const Features = () => {
       <Box
         mt={10}
         width="100%"
-        height={{ xs: "50rem", md: "75rem", lg: "25rem" }}
+        height={{ xs: "50rem", md: "45rem", lg: "25rem" }}
       >
         <div>
           <StyledBackgroudVector

--- a/frontend/components/Features.tsx
+++ b/frontend/components/Features.tsx
@@ -106,8 +106,6 @@ const StyledBackgroudVector = styled(Image)(({ theme }) => ({
 }));
 
 const StyledCardParent = styled("div")(({ theme }) => ({
-  marginTop: "0%",
-  paddingBottom: "0%",
   position: "absolute",
   display: "flex",
   flexDirection: "row",
@@ -125,9 +123,5 @@ const StyledCardParent = styled("div")(({ theme }) => ({
   [theme.breakpoints.down("md")]: {
     marginTop: "20%",
     paddingBottom: "15%",
-  },
-  [theme.breakpoints.down("sm")]: {
-    marginTop: "35%",
-    paddingBottom: "10%",
   },
 }));

--- a/frontend/components/Features.tsx
+++ b/frontend/components/Features.tsx
@@ -23,7 +23,11 @@ const Features = () => {
         />
         <StyledHeading>Our Features</StyledHeading>
       </div>
-      <Box mt={10} width="100%" height={{ xs: "75rem", lg: "25rem" }}>
+      <Box
+        mt={10}
+        width="100%"
+        height={{ xs: "50rem", md: "75rem", lg: "25rem" }}
+      >
         <div>
           <StyledBackgroudVector
             src="/assets/landing_page/feature_background.png"


### PR DESCRIPTION
CHANGES: 
fixed the spacing for mobile and tablet sized view for the landing page, in between features and FAQs. 
Added tests for features to make sure everything is still visible. 

HOW TO VIEW: 
Go to landing page and scroll until the end of features and start of FAQs 


Attached is a screenshot of the new spacing. 

<img width="403" alt="Screen Shot 2024-03-28 at 6 43 52 pm" src="https://github.com/devsoc-unsw/freerooms/assets/161106005/720912f4-a776-48d2-bf84-7672e567224c">

