### PR TITLE
461 - Fix building room pages being cut-off on mobile views

### DIFF
--- a/frontend/__tests__/BuildingDrawer.test.tsx
+++ b/frontend/__tests__/BuildingDrawer.test.tsx
@@ -72,4 +72,40 @@ describe("BuildingDrawer", () => {
     expect(drawer).toBeInTheDocument();
     expect(getComputedStyle(drawer).getPropertyValue("width")).toBe("100%");
   });
+
+  it("Correct building name is displayed", () => {
+    renderWithRedux(<BuildingDrawer open={true} />, {
+      preloadedState: {
+        currentBuilding: {
+          value: {
+            name: "Ainsworth",
+            id: "K-J17",
+            lat: 0,
+            long: 0,
+            aliases: [],
+          },
+        },
+      },
+    });
+    const buildingName = screen.getByText(/Ainsworth/i);
+    expect(buildingName).toBeInTheDocument();
+  });
+
+  it("Correct alternate description for image of building", () => {
+    renderWithRedux(<BuildingDrawer open={true} />, {
+      preloadedState: {
+        currentBuilding: {
+          value: {
+            name: "Ainsworth",
+            id: "K-J17",
+            lat: 0,
+            long: 0,
+            aliases: [],
+          },
+        },
+      },
+    });
+    const image = screen.getByAltText(/Image of building K-J17/i);
+    expect(image).toBeInTheDocument();
+  });
 });

--- a/frontend/__tests__/BuildingDrawer.test.tsx
+++ b/frontend/__tests__/BuildingDrawer.test.tsx
@@ -1,0 +1,75 @@
+import "@testing-library/jest-dom";
+
+import { useMediaQuery } from "@mui/material";
+import { screen } from "@testing-library/react";
+
+import BuildingDrawer from "../views/BuildingDrawer";
+import renderWithRedux from "./utils/renderWithRedux";
+
+jest.mock("react-redux", () => ({
+  ...jest.requireActual("react-redux"),
+  useDispatch: jest.fn(),
+}));
+jest.mock("@mui/material", () => ({
+  ...jest.requireActual("@mui/material"),
+  useMediaQuery: jest.fn().mockReturnValue(false),
+}));
+
+describe("BuildingDrawer", () => {
+  it("Building Drawer shows close button", () => {
+    renderWithRedux(<BuildingDrawer open={true} />, {
+      preloadedState: {
+        currentBuilding: {
+          value: {
+            name: "Ainsworth",
+            id: "K-J17",
+            lat: 0,
+            long: 0,
+            aliases: [],
+          },
+        },
+      },
+    });
+    const button = screen.getByRole("button", { name: /close/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("Building Drawer has correct width default (non-mobile view)", () => {
+    renderWithRedux(<BuildingDrawer open={true} />, {
+      preloadedState: {
+        currentBuilding: {
+          value: {
+            name: "Ainsworth",
+            id: "K-J17",
+            lat: 0,
+            long: 0,
+            aliases: [],
+          },
+        },
+      },
+    });
+    const drawer = screen.getByLabelText(/building-drawer/i);
+    expect(drawer).toBeInTheDocument();
+    expect(getComputedStyle(drawer).getPropertyValue("width")).toBe("400px");
+  });
+
+  it("Building Drawer has correct width for mobile view", () => {
+    (useMediaQuery as unknown as jest.Mock).mockReturnValue(true);
+    renderWithRedux(<BuildingDrawer open={true} />, {
+      preloadedState: {
+        currentBuilding: {
+          value: {
+            name: "Ainsworth",
+            id: "K-J17",
+            lat: 0,
+            long: 0,
+            aliases: [],
+          },
+        },
+      },
+    });
+    const drawer = screen.getByLabelText(/building-drawer/i);
+    expect(drawer).toBeInTheDocument();
+    expect(getComputedStyle(drawer).getPropertyValue("width")).toBe("100%");
+  });
+});

--- a/frontend/views/BuildingDrawer.tsx
+++ b/frontend/views/BuildingDrawer.tsx
@@ -1,12 +1,12 @@
 import { RoomStatus } from "@common/types";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import CloseIcon from "@mui/icons-material/Close";
-import { Typography, TypographyProps } from "@mui/material";
+import { Typography, TypographyProps, useMediaQuery } from "@mui/material";
 import Box, { BoxProps } from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
 import Divider from "@mui/material/Divider";
 import Drawer from "@mui/material/Drawer";
-import { styled } from "@mui/material/styles";
+import { styled, useTheme } from "@mui/material/styles";
 import TextField, { TextFieldProps } from "@mui/material/TextField";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { DesktopDatePicker } from "@mui/x-date-pickers/DesktopDatePicker";
@@ -95,12 +95,15 @@ const RoomBoxSubheading = styled(Typography)<TypographyProps>(({ theme }) => ({
 }));
 
 export const drawerWidth = 400;
+const drawerWidthMobile = "100%";
 
 const BuildingDrawer: React.FC<{ open: boolean }> = ({ open }) => {
   const dispatch = useDispatch();
   const datetime = useSelector(selectDatetime);
   const building = useSelector(selectCurrentBuilding);
   const { status: rooms } = useBuildingStatus(building?.id ?? "");
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   if (!building || !open) return <></>;
 
@@ -200,10 +203,10 @@ const BuildingDrawer: React.FC<{ open: boolean }> = ({ open }) => {
   return (
     <Drawer
       sx={{
-        width: drawerWidth,
+        width: isMobile ? drawerWidthMobile : drawerWidth,
         flexShrink: 0,
         "& .MuiDrawer-paper": {
-          width: drawerWidth,
+          width: isMobile ? drawerWidthMobile : drawerWidth,
           boxSizing: "border-box",
         },
       }}

--- a/frontend/views/BuildingDrawer.tsx
+++ b/frontend/views/BuildingDrawer.tsx
@@ -213,6 +213,7 @@ const BuildingDrawer: React.FC<{ open: boolean }> = ({ open }) => {
       variant="persistent"
       anchor="right"
       open={true}
+      aria-label="building-drawer"
     >
       <Divider />
       <MainBox>


### PR DESCRIPTION
### Summary of changes
- previously had the mobile view of a room page cut off:
<img width="315" alt="image" src="https://github.com/devsoc-unsw/freerooms/assets/29350857/e7e9b74f-2e41-4b2d-8867-8bc6836f513d">

- now has been fixed so that after the small mobile breakpoint is crossed, the room page will take up the whole page width instead of having it fixed to 400px
<img width="312" alt="image" src="https://github.com/devsoc-unsw/freerooms/assets/29350857/e620efca-f945-4ac2-8bfb-be4c0ade58e9">


### Viewing changes
- run branch locally and have the app in a mobile view (< 600px wide) and click on any building to see card