### PR TITLE
459 - fix: stop styled component from forwarding `isalternate` prop

### DIFF
--- a/frontend/components/Landing.tsx
+++ b/frontend/components/Landing.tsx
@@ -73,16 +73,17 @@ interface StyledImageProps {
   $isalternate: boolean;
 }
 
-const StyledImage = styled(Image, transientOptions)<StyledImageProps>(
-  ({ theme, $isalternate }) => ({
-    height: "100%",
-    width: "100%",
-    display: $isalternate ? "block" : "none",
-    [theme.breakpoints.down("md")]: {
-      display: $isalternate ? "none" : "block",
-    },
-  })
-);
+const StyledImage = styled(
+  Image,
+  transientOptions
+)<StyledImageProps>(({ theme, $isalternate }) => ({
+  height: "100%",
+  width: "100%",
+  display: $isalternate ? "block" : "none",
+  [theme.breakpoints.down("md")]: {
+    display: $isalternate ? "none" : "block",
+  },
+}));
 
 const HeroPanelContainer = styled(Stack)(({ theme }) => ({
   height: "100%",

--- a/frontend/components/Landing.tsx
+++ b/frontend/components/Landing.tsx
@@ -3,6 +3,7 @@ import { styled } from "@mui/material/styles";
 import Image from "next/image";
 import React, { useState } from "react";
 
+import transientOptions from "../utils/transientOptions";
 import Faq from "./Faq";
 import Features from "./Features";
 import Sponsors from "./Sponsors";
@@ -40,14 +41,14 @@ const Landing = () => {
           <StyledImage
             src="/assets/landing_page/hero_panel.svg"
             alt="hero panel"
-            isalternate
+            $isalternate
             width="1249"
             height="1067"
           />
           <StyledImage
             src={"/assets/landing_page/hero_panel_mobile.svg"}
             alt="hero panel"
-            isalternate={false}
+            $isalternate={false}
             width="562"
             height="547"
           />
@@ -69,16 +70,16 @@ const LandingScreenContainer = styled(Stack)(({ theme }) => ({
 }));
 
 interface StyledImageProps {
-  isalternate: boolean;
+  $isalternate: boolean;
 }
 
-const StyledImage = styled(Image)<StyledImageProps>(
-  ({ theme, isalternate }) => ({
+const StyledImage = styled(Image, transientOptions)<StyledImageProps>(
+  ({ theme, $isalternate }) => ({
     height: "100%",
     width: "100%",
-    display: isalternate ? "block" : "none",
+    display: $isalternate ? "block" : "none",
     [theme.breakpoints.down("md")]: {
-      display: isalternate ? "none" : "block",
+      display: $isalternate ? "none" : "block",
     },
   })
 );

--- a/frontend/utils/transientOptions.ts
+++ b/frontend/utils/transientOptions.ts
@@ -1,0 +1,8 @@
+import { CreateStyled } from "@emotion/styled";
+
+// see https://github.com/emotion-js/emotion/issues/2193
+const transientOptions: Parameters<CreateStyled>[1] = {
+  shouldForwardProp: (propName: string) => !propName.startsWith("$"),
+};
+
+export default transientOptions;


### PR DESCRIPTION
ticket: https://github.com/devsoc-unsw/freerooms/issues/459

prevent forwarding `isalternate` prop to the underlying html by using a shouldForwardProp option and only forwarding prop when they don't start with $.