### PR TITLE
513 - Add filter sidebar for all rooms page

### DIFF
--- a/frontend/__tests__/DropdownSelections.test.tsx
+++ b/frontend/__tests__/DropdownSelections.test.tsx
@@ -1,0 +1,61 @@
+import "@testing-library/jest-dom";
+
+import { createTheme, ThemeProvider } from "@mui/material";
+import { render, screen, within } from "@testing-library/react";
+
+import DropdownSelections from "../components/DropdownSelections";
+
+describe("DropdownSelections", () => {
+  it("Displays the correct filter type given", () => {
+    render(
+      <ThemeProvider theme={createTheme({})}>
+        <DropdownSelections
+          dropdown={{
+            text: "Room Capacity",
+            key: "capacity",
+            items: [
+              {
+                text: "25+",
+                value: "25",
+              },
+              {
+                text: "50+",
+                value: "50",
+              },
+              {
+                text: "100+",
+                value: "100",
+              },
+              {
+                text: "200+",
+                value: "200",
+              },
+            ],
+          }}
+          canSelectMultiple={false}
+          filters={{
+            capacity: "",
+            usage: "",
+            location: "",
+            duration: "",
+            id: "",
+          }}
+          handleSelect={(key, item) => {
+            return;
+          }}
+        />
+      </ThemeProvider>
+    );
+    const filterTitle = screen.getByText("Room Capacity");
+    expect(filterTitle).toBeInTheDocument();
+
+    const filterItem25 = screen.getByText("25+");
+    expect(filterItem25).toBeInTheDocument();
+    const filterItem50 = screen.getByText("50+");
+    expect(filterItem50).toBeInTheDocument();
+    const filterItem100 = screen.getByText("100+");
+    expect(filterItem100).toBeInTheDocument();
+    const filterItem200 = screen.getByText("200+");
+    expect(filterItem200).toBeInTheDocument();
+  });
+});

--- a/frontend/app/browse/page.tsx
+++ b/frontend/app/browse/page.tsx
@@ -6,7 +6,6 @@ import { styled } from "@mui/material/styles";
 import React from "react";
 
 import FilterBar from "../../components/FilterBar";
-import FilterSideBar from "../../components/FilterSideBar";
 import SearchBar from "../../components/SearchBar";
 import SortBar from "../../components/SortBar";
 import CardList from "../../views/CardList";
@@ -18,20 +17,19 @@ const Page = () => {
 
   return (
     <Container maxWidth={false}>
-      {/* <Tiles>
+      <Tiles>
         <Stack
           direction="row"
           justifyContent="space-between"
           my={1}
           flexWrap={{ xs: "wrap", sm: "nowrap" }}
-        > */}
-      {/* <FilterBar /> */}
-      <FilterSideBar />
-      {/* <SearchBar setQuery={setQuery} />
+        >
+          <FilterBar />
+          <SearchBar setQuery={setQuery} />
           <SortBar setSort={setSort} sort={sort} />
         </Stack>
         <CardList sort={sort} query={query} />
-      </Tiles> */}
+      </Tiles>
     </Container>
   );
 };

--- a/frontend/app/browse/page.tsx
+++ b/frontend/app/browse/page.tsx
@@ -6,6 +6,7 @@ import { styled } from "@mui/material/styles";
 import React from "react";
 
 import FilterBar from "../../components/FilterBar";
+import FilterSideBar from "../../components/FilterSideBar";
 import SearchBar from "../../components/SearchBar";
 import SortBar from "../../components/SortBar";
 import CardList from "../../views/CardList";
@@ -17,19 +18,20 @@ const Page = () => {
 
   return (
     <Container maxWidth={false}>
-      <Tiles>
+      {/* <Tiles>
         <Stack
           direction="row"
           justifyContent="space-between"
           my={1}
           flexWrap={{ xs: "wrap", sm: "nowrap" }}
-        >
-          <FilterBar />
-          <SearchBar setQuery={setQuery} />
+        > */}
+      {/* <FilterBar /> */}
+      <FilterSideBar />
+      {/* <SearchBar setQuery={setQuery} />
           <SortBar setSort={setSort} sort={sort} />
         </Stack>
         <CardList sort={sort} query={query} />
-      </Tiles>
+      </Tiles> */}
     </Container>
   );
 };

--- a/frontend/components/DropdownSelections.tsx
+++ b/frontend/components/DropdownSelections.tsx
@@ -6,7 +6,7 @@ import Checkbox from "@mui/material/Checkbox";
 import Radio from "@mui/material/Radio";
 import { styled } from "@mui/system";
 import React from "react";
-import { DropDown, DropDownItem, Filters } from "types";
+import { AllRoomsFilter, DropDown, DropDownItem, Filters } from "types";
 
 const StyledAccordian = styled(Accordion)(({ theme }) => ({
   transition: "all 0.1s ease-in-out",
@@ -24,8 +24,11 @@ const StyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({
 const DropdownSelections: React.FC<{
   dropdown: DropDown;
   canSelectMultiple: boolean;
-  filters: Filters;
-  handleSelect: (key: keyof Filters, item: DropDownItem) => void;
+  filters: Filters | AllRoomsFilter;
+  handleSelect: (
+    key: keyof Filters | keyof AllRoomsFilter,
+    item: DropDownItem
+  ) => void;
 }> = ({ dropdown, canSelectMultiple, filters, handleSelect }) => {
   return (
     <StyledAccordian
@@ -47,7 +50,7 @@ const DropdownSelections: React.FC<{
             key={item.value}
           >
             {canSelectMultiple ? (
-              <Checkbox checked={filters[dropdown.key] === item.value} />
+              <Checkbox checked={filters[dropdown.key]?.includes(item.value)} />
             ) : (
               <Radio checked={filters[dropdown.key] === item.value} />
             )}

--- a/frontend/components/DropdownSelections.tsx
+++ b/frontend/components/DropdownSelections.tsx
@@ -50,9 +50,15 @@ const DropdownSelections: React.FC<{
             key={item.value}
           >
             {canSelectMultiple ? (
-              <Checkbox checked={filters[dropdown.key]?.includes(item.value)} />
+              <Checkbox
+                checked={filters[dropdown.key]?.includes(item.value)}
+                role="checkbox"
+              />
             ) : (
-              <Radio checked={filters[dropdown.key] === item.value} />
+              <Radio
+                checked={filters[dropdown.key] === item.value}
+                role="radio"
+              />
             )}
             {item.text}
           </div>

--- a/frontend/components/DropdownSelections.tsx
+++ b/frontend/components/DropdownSelections.tsx
@@ -23,16 +23,20 @@ const StyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({
 
 const DropdownSelections: React.FC<{
   dropdown: DropDown;
-  multiple: boolean;
+  canSelectMultiple: boolean;
   filters: Filters;
   handleSelect: (key: keyof Filters, item: DropDownItem) => void;
-}> = ({ dropdown, multiple, filters, handleSelect }) => {
+}> = ({ dropdown, canSelectMultiple, filters, handleSelect }) => {
   return (
-    <StyledAccordian disableGutters={true}>
+    <StyledAccordian
+      disableGutters={true}
+      elevation={canSelectMultiple ? 0 : undefined}
+    >
       <AccordionSummary
         expandIcon={<ExpandMoreIcon />}
         aria-controls="panel1a-content"
         id="panel1a-header"
+        style={canSelectMultiple ? { padding: "10px 15px" } : {}}
       >
         {dropdown.text}
       </AccordionSummary>
@@ -42,7 +46,7 @@ const DropdownSelections: React.FC<{
             onClick={() => handleSelect(dropdown.key, item)}
             key={item.value}
           >
-            {multiple ? (
+            {canSelectMultiple ? (
               <Checkbox checked={filters[dropdown.key] === item.value} />
             ) : (
               <Radio checked={filters[dropdown.key] === item.value} />

--- a/frontend/components/DropdownSelections.tsx
+++ b/frontend/components/DropdownSelections.tsx
@@ -1,0 +1,58 @@
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Checkbox from "@mui/material/Checkbox";
+import Radio from "@mui/material/Radio";
+import { styled } from "@mui/system";
+import React from "react";
+import { DropDown, DropDownItem, Filters } from "types";
+
+const StyledAccordian = styled(Accordion)(({ theme }) => ({
+  transition: "all 0.1s ease-in-out",
+  backgroundColor: theme.palette.background.default,
+  "&:hover": {
+    backgroundColor: theme.palette.primary.main,
+    color: "#fff",
+  },
+}));
+const StyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({
+  backgroundColor: theme.palette.background.default,
+  color: theme.palette.text.primary,
+}));
+
+const DropdownSelections: React.FC<{
+  dropdown: DropDown;
+  multiple: boolean;
+  filters: Filters;
+  handleSelect: (key: keyof Filters, item: DropDownItem) => void;
+}> = ({ dropdown, multiple, filters, handleSelect }) => {
+  return (
+    <StyledAccordian disableGutters={true}>
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls="panel1a-content"
+        id="panel1a-header"
+      >
+        {dropdown.text}
+      </AccordionSummary>
+      <StyledAccordionDetails>
+        {dropdown.items.map((item) => (
+          <div
+            onClick={() => handleSelect(dropdown.key, item)}
+            key={item.value}
+          >
+            {multiple ? (
+              <Checkbox checked={filters[dropdown.key] === item.value} />
+            ) : (
+              <Radio checked={filters[dropdown.key] === item.value} />
+            )}
+            {item.text}
+          </div>
+        ))}
+      </StyledAccordionDetails>
+    </StyledAccordian>
+  );
+};
+
+export default DropdownSelections;

--- a/frontend/components/FilterBar.tsx
+++ b/frontend/components/FilterBar.tsx
@@ -21,6 +21,8 @@ import {
 } from "../redux/filtersSlice";
 import { useDispatch, useSelector } from "../redux/hooks";
 import { DropDown, DropDownItem, Filters } from "../types";
+import { filterBarDropdown } from "../utils/constants";
+import DropdownSelections from "./DropdownSelections";
 
 const StyledFilterButton = styled(Box)<BoxProps>(({ theme }) => ({
   height: 40,
@@ -104,29 +106,14 @@ const FilterBar = () => {
 
   const dropdownMap = useMemo(
     () =>
-      dropdowns.map((dropdown) => (
-        <StyledAccordian key={dropdown.key}>
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel1a-content"
-            id="panel1a-header"
-          >
-            {dropdown.text}
-          </AccordionSummary>
-          <StyledAccordionDetails>
-            <div>
-              {dropdown.items.map((item) => (
-                <div
-                  onClick={() => handleSelect(dropdown.key, item)}
-                  key={item.value}
-                >
-                  <Radio checked={filters[dropdown.key] === item.value} />
-                  {item.text}
-                </div>
-              ))}
-            </div>
-          </StyledAccordionDetails>
-        </StyledAccordian>
+      filterBarDropdown.map((dropdown) => (
+        <DropdownSelections
+          key={dropdown.key}
+          dropdown={dropdown}
+          multiple={false}
+          filters={filters}
+          handleSelect={handleSelect}
+        />
       )),
     [filters, handleSelect]
   );
@@ -165,89 +152,5 @@ const FilterBar = () => {
     </ClickAwayListener>
   );
 };
-
-// Dropdowns and items.
-const dropdowns: DropDown[] = [
-  {
-    text: "Room Type",
-    key: "usage",
-    items: Object.entries(roomUsages).map(([abbr, usage]) => ({
-      text: usage,
-      value: abbr,
-    })),
-  },
-  {
-    text: "Room Capacity",
-    key: "capacity",
-    items: [
-      {
-        text: "25+",
-        value: "25",
-      },
-      {
-        text: "50+",
-        value: "50",
-      },
-      {
-        text: "100+",
-        value: "100",
-      },
-      {
-        text: "200+",
-        value: "200",
-      },
-    ],
-  },
-  {
-    text: "Duration Free",
-    key: "duration",
-    items: [
-      {
-        text: "30+ minutes",
-        value: "30",
-      },
-      {
-        text: "1+ hours",
-        value: "60",
-      },
-      {
-        text: "2+ hours",
-        value: "120",
-      },
-      {
-        text: "3+ hours",
-        value: "180",
-      },
-    ],
-  },
-  {
-    text: "Location",
-    key: "location",
-    items: [
-      {
-        text: "Upper Campus",
-        value: "upper",
-      },
-      {
-        text: "Lower Campus",
-        value: "lower",
-      },
-    ],
-  },
-  {
-    text: "ID Required",
-    key: "id",
-    items: [
-      {
-        text: "Not Required",
-        value: "false",
-      },
-      {
-        text: "Required",
-        value: "true",
-      },
-    ],
-  },
-];
 
 export default FilterBar;

--- a/frontend/components/FilterBar.tsx
+++ b/frontend/components/FilterBar.tsx
@@ -11,7 +11,7 @@ import Radio from "@mui/material/Radio";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import React, { useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 
 import {
   clearFilters,
@@ -89,32 +89,47 @@ const FilterBar = () => {
   const [open, setOpen] = useState(false);
 
   // Handle user selecting a filter, each dropdown select has an associated key
-  const handleSelect = (key: keyof Filters, item: DropDownItem) => {
-    if (filters[key] === item.value) {
-      // If the same as already selected, unset key
-      dispatch(unsetFilter(key));
-    } else {
-      // Otherwise, spread existing filters and set key
-      dispatch(setFilter({ key, value: item.value }));
-    }
-  };
+  const handleSelect = useCallback(
+    (key: keyof Filters, item: DropDownItem) => {
+      if (filters[key] === item.value) {
+        // If the same as already selected, unset key
+        dispatch(unsetFilter(key));
+      } else {
+        // Otherwise, spread existing filters and set key
+        dispatch(setFilter({ key, value: item.value }));
+      }
+    },
+    [dispatch, filters]
+  );
 
-  // Reveal dropdown items
-  const dropdownReveal = (dropdown: DropDown) => {
-    return (
-      <div>
-        {dropdown.items.map((item) => (
-          <div
-            onClick={() => handleSelect(dropdown.key, item)}
-            key={item.value}
+  const dropdownMap = useMemo(
+    () =>
+      dropdowns.map((dropdown) => (
+        <StyledAccordian key={dropdown.key}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1a-content"
+            id="panel1a-header"
           >
-            <Radio checked={filters[dropdown.key] === item.value} />
-            {item.text}
-          </div>
-        ))}
-      </div>
-    );
-  };
+            {dropdown.text}
+          </AccordionSummary>
+          <StyledAccordionDetails>
+            <div>
+              {dropdown.items.map((item) => (
+                <div
+                  onClick={() => handleSelect(dropdown.key, item)}
+                  key={item.value}
+                >
+                  <Radio checked={filters[dropdown.key] === item.value} />
+                  {item.text}
+                </div>
+              ))}
+            </div>
+          </StyledAccordionDetails>
+        </StyledAccordian>
+      )),
+    [filters, handleSelect]
+  );
 
   return (
     <ClickAwayListener onClickAway={() => setOpen(false)}>
@@ -142,20 +157,7 @@ const FilterBar = () => {
                   Reset
                 </Typography>
               </StyledHeader>
-              {dropdowns.map((dropdown) => (
-                <StyledAccordian key={dropdown.key}>
-                  <AccordionSummary
-                    expandIcon={<ExpandMoreIcon />}
-                    aria-controls="panel1a-content"
-                    id="panel1a-header"
-                  >
-                    {dropdown.text}
-                  </AccordionSummary>
-                  <StyledAccordionDetails>
-                    {dropdownReveal(dropdown)}
-                  </StyledAccordionDetails>
-                </StyledAccordian>
-              ))}
+              {dropdownMap}
             </StyledDropDownMenu>
           </Container>
         )}

--- a/frontend/components/FilterBar.tsx
+++ b/frontend/components/FilterBar.tsx
@@ -1,13 +1,7 @@
-import { roomUsages } from "@common/roomUsages";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import FilterAltIcon from "@mui/icons-material/FilterAlt";
 import { ClickAwayListener } from "@mui/material";
-import Accordion from "@mui/material/Accordion";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import AccordionSummary from "@mui/material/AccordionSummary";
 import Box, { BoxProps } from "@mui/material/Box";
 import Container from "@mui/material/Container";
-import Radio from "@mui/material/Radio";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -68,20 +62,6 @@ const StyledHeader = styled(Box)<BoxProps>(() => ({
   gap: 135,
 }));
 
-const StyledAccordian = styled(Accordion)(({ theme }) => ({
-  transition: "all 0.1s ease-in-out",
-  backgroundColor: theme.palette.background.default,
-  "&:hover": {
-    backgroundColor: theme.palette.primary.main,
-    color: "#fff",
-  },
-}));
-
-const StyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({
-  backgroundColor: theme.palette.background.default,
-  color: theme.palette.text.primary,
-}));
-
 const FilterBar = () => {
   // Get filters from Redux
   const dispatch = useDispatch();
@@ -110,7 +90,7 @@ const FilterBar = () => {
         <DropdownSelections
           key={dropdown.key}
           dropdown={dropdown}
-          multiple={false}
+          canSelectMultiple={false}
           filters={filters}
           handleSelect={handleSelect}
         />

--- a/frontend/components/FilterSideBar.tsx
+++ b/frontend/components/FilterSideBar.tsx
@@ -1,0 +1,70 @@
+import { Box } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import { BoxProps } from "@mui/system";
+import { useCallback, useMemo } from "react";
+import {
+  selectAllRoomsFilters,
+  setAllRoomsFilter,
+  unsetAllRoomsFilter,
+} from "redux/allRoomsFilterSlice";
+import { useDispatch, useSelector } from "redux/hooks";
+import { AllRoomsFilter, DropDownItem } from "types";
+import { allRoomsFilterDropdown } from "utils/constants";
+
+import DropdownSelections from "./DropdownSelections";
+
+const StyledFilterSideBarContainer = styled(Box)<BoxProps>(({ theme }) => ({
+  width: 450,
+  top: 100,
+  left: 100,
+  borderRadius: 10,
+  display: "flex",
+  flexDirection: "column",
+  position: "absolute",
+  backgroundColor: theme.palette.background.default,
+  borderWidth: 1,
+  borderStyle: "solid",
+  borderColor: theme.palette.mode === "light" ? "#BCBCBC" : "#3F3F3F",
+  ":hover": {
+    cursor: "auto",
+  },
+}));
+
+const FilterSideBar = () => {
+  const dispatch = useDispatch();
+  const filters = useSelector(selectAllRoomsFilters);
+
+  // Handle user selecting a filter, each dropdown select has an associated key
+  const handleSelect = useCallback(
+    (key: keyof AllRoomsFilter, item: DropDownItem) => {
+      if (filters[key]?.includes(item.value)) {
+        // If the same as already selected, unset key
+        dispatch(unsetAllRoomsFilter({ key, value: item.value }));
+      } else {
+        // Otherwise, spread existing filters and set key
+        dispatch(setAllRoomsFilter({ key, value: item.value }));
+      }
+    },
+    [dispatch, filters]
+  );
+
+  const dropdownMap = useMemo(
+    () =>
+      allRoomsFilterDropdown.map((dropdown) => (
+        <DropdownSelections
+          key={dropdown.key}
+          dropdown={dropdown}
+          canSelectMultiple={true}
+          filters={filters}
+          handleSelect={handleSelect}
+        />
+      )),
+    [filters, handleSelect]
+  );
+
+  return (
+    <StyledFilterSideBarContainer>{dropdownMap}</StyledFilterSideBarContainer>
+  );
+};
+
+export default FilterSideBar;

--- a/frontend/redux/allRoomsFilterSlice.ts
+++ b/frontend/redux/allRoomsFilterSlice.ts
@@ -1,0 +1,54 @@
+/**
+ * Redux slice to manage the selected filters
+ */
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+import { AllRoomsFilter } from "../types";
+import { RootState } from "./store";
+
+interface RoomsFilterState {
+  value: AllRoomsFilter;
+}
+
+const initialState: RoomsFilterState = {
+  value: {},
+};
+
+const filtersSlice = createSlice({
+  name: "filters",
+  initialState,
+  reducers: {
+    setAllRoomsFilter: (
+      state,
+      action: PayloadAction<{ key: keyof AllRoomsFilter; value: string }>
+    ) => {
+      const { key, value } = action.payload;
+      state.value[key]?.push(value);
+    },
+    unsetAllRoomsFilter: (
+      state,
+      action: PayloadAction<{ key: keyof AllRoomsFilter; value: string }>
+    ) => {
+      const { key, value } = action.payload;
+      if (Object.keys(state.value).includes(key)) {
+        console.log(key, value);
+        const { ...otherFilters } = state.value;
+        const targetIndex = otherFilters["usage"]?.indexOf(value);
+        if (targetIndex && targetIndex > -1)
+          otherFilters["usage"]?.splice(targetIndex, 1);
+        state.value = otherFilters;
+      }
+    },
+    clearAllRoomsFilters: (state) => {
+      state.value = {};
+    },
+  },
+});
+
+export const { setAllRoomsFilter, unsetAllRoomsFilter, clearAllRoomsFilters } =
+  filtersSlice.actions;
+
+export const selectAllRoomsFilters = (state: RootState) =>
+  state.allRoomsFilters.value;
+
+export default filtersSlice.reducer;

--- a/frontend/redux/allRoomsFilterSlice.ts
+++ b/frontend/redux/allRoomsFilterSlice.ts
@@ -15,7 +15,7 @@ const initialState: RoomsFilterState = {
 };
 
 const filtersSlice = createSlice({
-  name: "filters",
+  name: "allRoomsFilters",
   initialState,
   reducers: {
     setAllRoomsFilter: (
@@ -23,6 +23,9 @@ const filtersSlice = createSlice({
       action: PayloadAction<{ key: keyof AllRoomsFilter; value: string }>
     ) => {
       const { key, value } = action.payload;
+      if (!Object.keys(state.value).includes(key)) {
+        state.value[key] = [];
+      }
       state.value[key]?.push(value);
     },
     unsetAllRoomsFilter: (

--- a/frontend/redux/store.ts
+++ b/frontend/redux/store.ts
@@ -1,5 +1,6 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 
+import allRoomsFilterSlice from "./allRoomsFilterSlice";
 import currentBuildingReducer from "./currentBuildingSlice";
 import datetimeReducer from "./datetimeSlice";
 import filtersReducer from "./filtersSlice";
@@ -11,6 +12,7 @@ const rootReducer = combineReducers({
   datetime: datetimeReducer,
   filters: filtersReducer,
   searchOpen: searchOpenSlice,
+  allRoomsFilters: allRoomsFilterSlice,
 });
 
 export const setupStore = (preloadedState?: Partial<RootState>) => {

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -46,6 +46,14 @@ export type Filters = {
   id?: string;
 };
 
+export type AllRoomsFilter = {
+  capacity?: string[];
+  usage?: string[];
+  location?: string[];
+  duration?: string[];
+  id?: string[];
+};
+
 export type Sponsor = {
   name: string;
   image: string;

--- a/frontend/utils/constants.ts
+++ b/frontend/utils/constants.ts
@@ -1,0 +1,126 @@
+import { roomUsages } from "@common/roomUsages";
+import { DropDown } from "types";
+
+// Dropdown & items for FilterBar in building browse page
+export const filterBarDropdown: DropDown[] = [
+  {
+    text: "Room Type",
+    key: "usage",
+    items: Object.entries(roomUsages).map(([abbr, usage]) => ({
+      text: usage,
+      value: abbr,
+    })),
+  },
+  {
+    text: "Room Capacity",
+    key: "capacity",
+    items: [
+      {
+        text: "25+",
+        value: "25",
+      },
+      {
+        text: "50+",
+        value: "50",
+      },
+      {
+        text: "100+",
+        value: "100",
+      },
+      {
+        text: "200+",
+        value: "200",
+      },
+    ],
+  },
+  {
+    text: "Duration Free",
+    key: "duration",
+    items: [
+      {
+        text: "30+ minutes",
+        value: "30",
+      },
+      {
+        text: "1+ hours",
+        value: "60",
+      },
+      {
+        text: "2+ hours",
+        value: "120",
+      },
+      {
+        text: "3+ hours",
+        value: "180",
+      },
+    ],
+  },
+  {
+    text: "Location",
+    key: "location",
+    items: [
+      {
+        text: "Upper Campus",
+        value: "upper",
+      },
+      {
+        text: "Lower Campus",
+        value: "lower",
+      },
+    ],
+  },
+  {
+    text: "ID Required",
+    key: "id",
+    items: [
+      {
+        text: "Not Required",
+        value: "false",
+      },
+      {
+        text: "Required",
+        value: "true",
+      },
+    ],
+  },
+];
+
+// Dropdowns and items for FilterSideBar in all-rooms-page
+export const allRoomsFilterDropdown: DropDown[] = [
+  {
+    text: "Room Type",
+    key: "usage",
+    items: Object.entries(roomUsages).map(([abbr, usage]) => ({
+      text: usage,
+      value: abbr,
+    })),
+  },
+  {
+    text: "Location",
+    key: "location",
+    items: [
+      {
+        text: "Upper Campus",
+        value: "upper",
+      },
+      {
+        text: "Lower Campus",
+        value: "lower",
+      },
+    ],
+  },
+  {
+    text: "ID Required",
+    key: "id",
+    items: [
+      {
+        text: "Not Required",
+        value: "false",
+      },
+      {
+        text: "Required",
+        value: "true",
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Overview

To filter all room pages, we will require a filter sidebar to filter room type, location & id required. Refactored the code for a dropdown selection menu for re-usability in codebase.

- also noticed that the filter dropdown had unnecessary padding so removed that too.

## How to view

- add placeholder filter dropdown in any page in local dev environment

## Changes
![image](https://github.com/user-attachments/assets/779664c0-690c-448b-ab66-57d5b4cc71d9)
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/fa0430cd-a7a8-462a-9c59-c4c074c86ada">
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/a3ee6f5e-213c-43b4-853f-1d87d68883d2">
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/b97fd25a-a376-458d-a10a-9b3cb6eeb8be">
