### PR TITLE
501 - Create the skeleton of the page and add icon at top to navigate to it

### DIFF
--- a/frontend/app/allRooms/page.tsx
+++ b/frontend/app/allRooms/page.tsx
@@ -47,14 +47,14 @@ export default function Page() {
   );
 }
 
-function SubFilterOptions() {
-  const [width, setWidth] = useState(window.innerWidth);
+function GetWindowSize() {
+  const [width, setWidth] = useState(0);
+
+  const handleResize = () => {
+    setWidth(window.innerWidth);
+  };
 
   useEffect(() => {
-    const handleResize = () => {
-      setWidth(window.innerWidth);
-    };
-
     window.addEventListener("resize", handleResize);
 
     return () => {
@@ -87,23 +87,23 @@ const MainFilter: React.FC<{}> = () => {
 const SubFilter: React.FC<{}> = () => {
   return (
     <Stack
-      flexDirection={SubFilterOptions() <= 690 ? "row" : "column"}
+      flexDirection={GetWindowSize() <= 690 ? "row" : "column"}
       style={{
         padding: 3,
         flexGrow: 1,
-        alignItems: SubFilterOptions() <= 690 ? "flex-start" : "stretch",
+        alignItems: GetWindowSize() <= 690 ? "center" : "stretch",
       }}
     >
       <StyledText
         style={{
+          paddingRight: 8,
           paddingBottom: 10,
         }}
       >
         Filter by:
       </StyledText>
       <Stack
-        spacing={1}
-        flexDirection={SubFilterOptions() <= 690 ? "row" : "column"}
+        flexDirection={GetWindowSize() <= 690 ? "row" : "column"}
         style={{
           marginLeft: 2,
           marginRight: 2,
@@ -224,7 +224,7 @@ const StyledText = styled(Typography)<TypographyProps>(({ theme }) => ({
 }));
 
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
-  // backgroundColor: theme.palette.background.default,
+  backgroundColor: theme.palette.background.default,
   boxShadow: "none",
   "&.MuiAccordion-root:before": {
     backgroundColor: theme.palette.background.default,

--- a/frontend/app/allRooms/page.tsx
+++ b/frontend/app/allRooms/page.tsx
@@ -1,211 +1,54 @@
 "use client";
 
-import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
-import EastIcon from "@mui/icons-material/East";
-import Accordion from "@mui/material/Accordion";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import AccordionSummary from "@mui/material/AccordionSummary";
+import ManageSearchIcon from "@mui/icons-material/ManageSearch";
 import Container from "@mui/material/Container";
-import Divider from "@mui/material/Divider";
 import Stack from "@mui/material/Stack";
-import Typography, { TypographyProps } from "@mui/material/Typography";
 import { styled } from "@mui/system";
-import React, { useEffect, useState } from "react";
+
+import AllRoomsFilter from "../../components/AllRoomsFilter";
+import Room from "../../components/AllRoomsRoom";
+import RoomList from "../../components/AllRoomsRoomList";
+import AllRoomsSearchBar from "../../components/AllRoomsSearchBar";
 
 export default function Page() {
   return (
     <Container>
       <Stack>
         <StyledSearchBar>
-          <MainFilter />
-          <SearchButton />
+          <AllRoomsSearchBar />
+          <ManageSearchIcon />
+          <></>
         </StyledSearchBar>
 
         <StyledBody>
-          <SubFilter />
-          {/* should insert a room list here */}
-          <Room>
-            <div
-              style={{
-                paddingLeft: 20,
-                fontWeight: "bold",
-              }}
-            >
-              Ainsworth G03
-            </div>
-            <div
-              style={{
-                paddingLeft: 20,
-              }}
-            >
-              Available Until 1:00pm
-            </div>
-          </Room>
+          <AllRoomsFilter />
+          <RoomList>
+            <Room building="Ainsworth G03" string="Available Until 1:00pm" />
+            <Room building="CSE Building K17" string="Available Until 1:00pm" />
+          </RoomList>
         </StyledBody>
       </Stack>
     </Container>
   );
 }
 
-function GetWindowSize() {
-  const [width, setWidth] = useState(0);
-
-  const handleResize = () => {
-    setWidth(window.innerWidth);
-  };
-
-  useEffect(() => {
-    window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
-
-  return width;
-}
-
-const MainFilter: React.FC<{}> = () => {
-  return (
-    <Stack
-      direction="row"
-      spacing={2}
-      divider={<Divider orientation="vertical" flexItem />}
-      style={{
-        justifyContent: "center",
-        flexGrow: 3,
-      }}
-    >
-      <Building />
-      <Capacity />
-      <When />
-      <Duration />
-    </Stack>
-  );
-};
-
-const SubFilter: React.FC<{}> = () => {
-  return (
-    <Stack
-      flexDirection={GetWindowSize() <= 690 ? "row" : "column"}
-      style={{
-        padding: 3,
-        flexGrow: 1,
-        alignItems: GetWindowSize() <= 690 ? "center" : "stretch",
-      }}
-    >
-      <StyledText
-        style={{
-          paddingRight: 8,
-          paddingBottom: 10,
-        }}
-      >
-        Filter by:
-      </StyledText>
-      <Stack
-        flexDirection={GetWindowSize() <= 690 ? "row" : "column"}
-        style={{
-          marginLeft: 2,
-          marginRight: 2,
-        }}
-      >
-        <StyledAccordion>
-          <AccordionSummary expandIcon={<ArrowDropDownIcon />}>
-            {"Room type"}
-          </AccordionSummary>
-          <AccordionDetails>{"Auditorium"}</AccordionDetails>
-        </StyledAccordion>
-
-        <StyledAccordion>
-          <AccordionSummary expandIcon={<ArrowDropDownIcon />}>
-            {"Location"}
-          </AccordionSummary>
-          <AccordionDetails>{"Upper Campus"}</AccordionDetails>
-        </StyledAccordion>
-
-        <StyledAccordion>
-          <AccordionSummary expandIcon={<ArrowDropDownIcon />}>
-            {"ID Required"}
-          </AccordionSummary>
-          <AccordionDetails>{"Not Required"}</AccordionDetails>
-        </StyledAccordion>
-      </Stack>
-    </Stack>
-  );
-};
-
-// all components below should either be moved to another file
-// or reconstructed into something else
-const Building: React.FC<{}> = () => {
-  return (
-    <Stack
-      style={{
-        flexGrow: 1,
-        paddingLeft: 5,
-      }}
-    >
-      Building
-    </Stack>
-  );
-};
-
-const Capacity: React.FC<{}> = () => {
-  return (
-    <Stack
-      style={{
-        flexGrow: 1,
-      }}
-    >
-      Capacity
-    </Stack>
-  );
-};
-
-const When: React.FC<{}> = () => {
-  return (
-    <Stack
-      style={{
-        flexGrow: 1,
-      }}
-    >
-      When
-    </Stack>
-  );
-};
-
-const Duration: React.FC<{}> = () => {
-  return (
-    <Stack
-      style={{
-        flexGrow: 1,
-      }}
-    >
-      Duration
-    </Stack>
-  );
-};
-
-const SearchButton: React.FC<{}> = () => {
-  return (
-    <Stack>
-      <EastIcon />
-    </Stack>
-  );
-};
-
 const StyledSearchBar = styled(Stack)(({ theme }) => ({
   flexDirection: "row",
-  minWidth: 0,
-  borderRadius: 7,
+  minWidth: "332px",
+  borderRadius: 8,
   borderStyle: "solid",
-  borderColor: "black",
   borderWidth: "thin",
-  marginTop: 48,
-  marginLeft: 32,
-  marginRight: 32,
-  marginBottom: 30,
+  borderColor: theme.palette.text.secondary,
+  margin: theme.spacing(6, 5, 3.75),
   padding: theme.spacing(1.25),
   justifyContent: "space-between",
+  alignItems: "center",
+  [theme.breakpoints.down("xs")]: {
+    spacing: 1,
+  },
+  [theme.breakpoints.up("xs")]: {
+    spacing: 2,
+  },
 }));
 
 const StyledBody = styled(Stack)(({ theme }) => ({
@@ -214,36 +57,5 @@ const StyledBody = styled(Stack)(({ theme }) => ({
   margin: theme.spacing(0, 4.25),
   padding: theme.spacing(2.5),
   justifyContent: "space-between",
-}));
-
-const StyledText = styled(Typography)<TypographyProps>(({ theme }) => ({
-  color: theme.palette.primary.main,
-  fontWeight: 700,
-  fontFamily: "Josefin Sans",
-  fontSize: "1rem",
-}));
-
-const StyledAccordion = styled(Accordion)(({ theme }) => ({
-  backgroundColor: theme.palette.background.default,
-  boxShadow: "none",
-  "&.MuiAccordion-root:before": {
-    backgroundColor: theme.palette.background.default,
-    height: 0,
-  },
-}));
-
-const Room = styled(Stack)(({ theme }) => ({
-  flexDirection: "row",
-  justifyContent: "space-between",
-  height: "fit-content",
-  flexGrow: 5,
-  borderRadius: 4,
-  borderStyle: "solid",
-  borderColor: "black",
-  borderWidth: "thin",
-  margin: 18,
-  paddingTop: 10,
-  paddingBottom: 10,
-  paddingLeft: 18,
-  paddingRight: 20,
+  backgroundColor: "yellow",
 }));

--- a/frontend/app/allRooms/page.tsx
+++ b/frontend/app/allRooms/page.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import SearchIcon from "@mui/icons-material/Search";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import EastIcon from "@mui/icons-material/East";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
 import Container from "@mui/material/Container";
 import Divider from "@mui/material/Divider";
 import Stack from "@mui/material/Stack";
+import Typography, { TypographyProps } from "@mui/material/Typography";
 import { styled } from "@mui/system";
+import React, { useEffect, useState } from "react";
 
 export default function Page() {
   return (
@@ -17,11 +23,46 @@ export default function Page() {
 
         <StyledBody>
           <SubFilter />
-          <RoomList />
+          {/* should insert a room list here */}
+          <Room>
+            <div
+              style={{
+                paddingLeft: 20,
+                fontWeight: "bold",
+              }}
+            >
+              Ainsworth G03
+            </div>
+            <div
+              style={{
+                paddingLeft: 20,
+              }}
+            >
+              Available Until 1:00pm
+            </div>
+          </Room>
         </StyledBody>
       </Stack>
     </Container>
   );
+}
+
+function SubFilterOptions() {
+  const [width, setWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return width;
 }
 
 const MainFilter: React.FC<{}> = () => {
@@ -30,7 +71,10 @@ const MainFilter: React.FC<{}> = () => {
       direction="row"
       spacing={2}
       divider={<Divider orientation="vertical" flexItem />}
-      style={{}}
+      style={{
+        justifyContent: "center",
+        flexGrow: 3,
+      }}
     >
       <Building />
       <Capacity />
@@ -42,106 +86,164 @@ const MainFilter: React.FC<{}> = () => {
 
 const SubFilter: React.FC<{}> = () => {
   return (
-    <Stack>
-      <span
+    <Stack
+      flexDirection={SubFilterOptions() <= 690 ? "row" : "column"}
+      style={{
+        padding: 3,
+        flexGrow: 1,
+        alignItems: SubFilterOptions() <= 690 ? "flex-start" : "stretch",
+      }}
+    >
+      <StyledText
         style={{
-          fontWeight: "bold",
-          paddingLeft: 6,
+          paddingBottom: 10,
         }}
       >
         Filter by:
-      </span>
+      </StyledText>
       <Stack
         spacing={1}
-        divider={<Divider orientation="horizontal" flexItem />}
+        flexDirection={SubFilterOptions() <= 690 ? "row" : "column"}
         style={{
-          padding: 3,
+          marginLeft: 2,
+          marginRight: 2,
         }}
       >
-        <RoomType />
-        <Location />
-        <IDRequired />
+        <StyledAccordion>
+          <AccordionSummary expandIcon={<ArrowDropDownIcon />}>
+            {"Room type"}
+          </AccordionSummary>
+          <AccordionDetails>{"Auditorium"}</AccordionDetails>
+        </StyledAccordion>
+
+        <StyledAccordion>
+          <AccordionSummary expandIcon={<ArrowDropDownIcon />}>
+            {"Location"}
+          </AccordionSummary>
+          <AccordionDetails>{"Upper Campus"}</AccordionDetails>
+        </StyledAccordion>
+
+        <StyledAccordion>
+          <AccordionSummary expandIcon={<ArrowDropDownIcon />}>
+            {"ID Required"}
+          </AccordionSummary>
+          <AccordionDetails>{"Not Required"}</AccordionDetails>
+        </StyledAccordion>
       </Stack>
     </Stack>
   );
 };
 
-const RoomList: React.FC<{}> = () => {
+// all components below should either be moved to another file
+// or reconstructed into something else
+const Building: React.FC<{}> = () => {
   return (
     <Stack
       style={{
-        borderStyle: "solid",
-        borderRadius: 3,
-        borderColor: "black",
-        borderWidth: "thin",
-        fontFamily: "Roboto",
+        flexGrow: 1,
+        paddingLeft: 5,
       }}
     >
-      Ainsworth G03 Available Until 1:00pm
+      Building
     </Stack>
   );
 };
 
-const Building: React.FC<{}> = () => {
-  return <Stack>Building</Stack>;
-};
-
 const Capacity: React.FC<{}> = () => {
-  return <Stack>Capacity</Stack>;
+  return (
+    <Stack
+      style={{
+        flexGrow: 1,
+      }}
+    >
+      Capacity
+    </Stack>
+  );
 };
 
 const When: React.FC<{}> = () => {
-  return <Stack>When</Stack>;
+  return (
+    <Stack
+      style={{
+        flexGrow: 1,
+      }}
+    >
+      When
+    </Stack>
+  );
 };
 
 const Duration: React.FC<{}> = () => {
-  return <Stack>Duration</Stack>;
+  return (
+    <Stack
+      style={{
+        flexGrow: 1,
+      }}
+    >
+      Duration
+    </Stack>
+  );
 };
 
 const SearchButton: React.FC<{}> = () => {
   return (
     <Stack>
-      <SearchIcon />
+      <EastIcon />
     </Stack>
   );
-};
-
-const RoomType: React.FC<{}> = () => {
-  return <Stack>Room Type</Stack>;
-};
-
-const Location: React.FC<{}> = () => {
-  return <Stack>Location</Stack>;
-};
-
-const IDRequired: React.FC<{}> = () => {
-  return <Stack>ID Required</Stack>;
 };
 
 const StyledSearchBar = styled(Stack)(({ theme }) => ({
   flexDirection: "row",
   minWidth: 0,
-  borderStyle: "solid",
   borderRadius: 7,
+  borderStyle: "solid",
   borderColor: "black",
   borderWidth: "thin",
   marginTop: 48,
   marginLeft: 32,
   marginRight: 32,
   marginBottom: 30,
-  padding: 10,
+  padding: theme.spacing(1.25),
   justifyContent: "space-between",
 }));
 
 const StyledBody = styled(Stack)(({ theme }) => ({
   flexDirection: "row",
   flexWrap: "wrap",
+  margin: theme.spacing(0, 4.25),
+  padding: theme.spacing(2.5),
+  justifyContent: "space-between",
+}));
+
+const StyledText = styled(Typography)<TypographyProps>(({ theme }) => ({
+  color: theme.palette.primary.main,
+  fontWeight: 700,
+  fontFamily: "Josefin Sans",
+  fontSize: "1rem",
+}));
+
+const StyledAccordion = styled(Accordion)(({ theme }) => ({
+  // backgroundColor: theme.palette.background.default,
+  boxShadow: "none",
+  "&.MuiAccordion-root:before": {
+    backgroundColor: theme.palette.background.default,
+    height: 0,
+  },
+}));
+
+const Room = styled(Stack)(({ theme }) => ({
+  flexDirection: "row",
+  justifyContent: "space-between",
+  height: "fit-content",
+  flexGrow: 5,
+  borderRadius: 4,
   borderStyle: "solid",
-  borderRadius: 3,
   borderColor: "black",
   borderWidth: "thin",
-  marginLeft: 40,
-  marginRight: 40,
-  paddingRight: 16,
-  backgroundColor: "pink",
+  margin: 18,
+  paddingTop: 10,
+  paddingBottom: 10,
+  paddingLeft: 18,
+  paddingRight: 20,
 }));

--- a/frontend/app/allRooms/page.tsx
+++ b/frontend/app/allRooms/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import ManageSearchIcon from "@mui/icons-material/ManageSearch";
+import { useMediaQuery } from "@mui/material";
 import Container from "@mui/material/Container";
 import Stack from "@mui/material/Stack";
-import { styled } from "@mui/system";
+import { styled, useTheme } from "@mui/system";
 
 import AllRoomsFilter from "../../components/AllRoomsFilter";
+import AllRoomsFilterMobile from "../../components/AllRoomsFilterMobile";
 import Room from "../../components/AllRoomsRoom";
 import RoomList from "../../components/AllRoomsRoomList";
 import AllRoomsSearchBar from "../../components/AllRoomsSearchBar";
@@ -21,7 +23,7 @@ export default function Page() {
         </StyledSearchBar>
 
         <StyledBody>
-          <AllRoomsFilter />
+          <Filter />
           <RoomList>
             <Room building="Ainsworth G03" string="Available Until 1:00pm" />
             <Room building="CSE Building K17" string="Available Until 1:00pm" />
@@ -57,5 +59,9 @@ const StyledBody = styled(Stack)(({ theme }) => ({
   margin: theme.spacing(0, 4.25),
   padding: theme.spacing(2.5),
   justifyContent: "space-between",
-  backgroundColor: "yellow",
 }));
+
+const Filter: React.FC<{}> = () => {
+  const displayMobile = useMediaQuery(useTheme().breakpoints.down("md"));
+  return <>{displayMobile ? <AllRoomsFilterMobile /> : <AllRoomsFilter />}</>;
+};

--- a/frontend/app/allRooms/page.tsx
+++ b/frontend/app/allRooms/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import SearchIcon from "@mui/icons-material/Search";
 import Container from "@mui/material/Container";
 import Divider from "@mui/material/Divider";
@@ -8,33 +10,15 @@ export default function Page() {
   return (
     <Container>
       <Stack>
-        <SearchBar />
-        <Stack
-          direction="row"
-          style={{
-            flexWrap: "wrap",
-            borderStyle: "solid",
-            borderRadius: 3,
-            borderColor: "black",
-            borderWidth: "thin",
-            marginLeft: 40,
-            marginRight: 40,
-            paddingRight: 16,
-          }}
-        >
-          <Stack>
-            <span
-              style={{
-                fontWeight: "bold",
-                paddingLeft: 6,
-              }}
-            >
-              Filter by:
-            </span>
-            <SubFilter />
-          </Stack>
+        <StyledSearchBar>
+          <MainFilter />
+          <SearchButton />
+        </StyledSearchBar>
+
+        <StyledBody>
+          <SubFilter />
           <RoomList />
-        </Stack>
+        </StyledBody>
       </Stack>
     </Container>
   );
@@ -56,27 +40,28 @@ const MainFilter: React.FC<{}> = () => {
   );
 };
 
-const SearchBar: React.FC<{}> = () => {
-  return (
-    <Stack direction="row">
-      <MainFilter />
-      <SearchButton />
-    </Stack>
-  );
-};
-
 const SubFilter: React.FC<{}> = () => {
   return (
-    <Stack
-      spacing={1}
-      divider={<Divider orientation="horizontal" flexItem />}
-      style={{
-        padding: 3,
-      }}
-    >
-      <RoomType />
-      <Location />
-      <IDRequired />
+    <Stack>
+      <span
+        style={{
+          fontWeight: "bold",
+          paddingLeft: 6,
+        }}
+      >
+        Filter by:
+      </span>
+      <Stack
+        spacing={1}
+        divider={<Divider orientation="horizontal" flexItem />}
+        style={{
+          padding: 3,
+        }}
+      >
+        <RoomType />
+        <Location />
+        <IDRequired />
+      </Stack>
     </Stack>
   );
 };
@@ -133,7 +118,8 @@ const IDRequired: React.FC<{}> = () => {
   return <Stack>ID Required</Stack>;
 };
 
-const StyledSearchBar = styled(SearchBar)(({ theme }) => ({
+const StyledSearchBar = styled(Stack)(({ theme }) => ({
+  flexDirection: "row",
   minWidth: 0,
   borderStyle: "solid",
   borderRadius: 7,
@@ -145,4 +131,17 @@ const StyledSearchBar = styled(SearchBar)(({ theme }) => ({
   marginBottom: 30,
   padding: 10,
   justifyContent: "space-between",
+}));
+
+const StyledBody = styled(Stack)(({ theme }) => ({
+  flexDirection: "row",
+  flexWrap: "wrap",
+  borderStyle: "solid",
+  borderRadius: 3,
+  borderColor: "black",
+  borderWidth: "thin",
+  marginLeft: 40,
+  marginRight: 40,
+  paddingRight: 16,
+  backgroundColor: "pink",
 }));

--- a/frontend/app/allRooms/page.tsx
+++ b/frontend/app/allRooms/page.tsx
@@ -1,0 +1,148 @@
+import SearchIcon from "@mui/icons-material/Search";
+import Container from "@mui/material/Container";
+import Divider from "@mui/material/Divider";
+import Stack from "@mui/material/Stack";
+import { styled } from "@mui/system";
+
+export default function Page() {
+  return (
+    <Container>
+      <Stack>
+        <SearchBar />
+        <Stack
+          direction="row"
+          style={{
+            flexWrap: "wrap",
+            borderStyle: "solid",
+            borderRadius: 3,
+            borderColor: "black",
+            borderWidth: "thin",
+            marginLeft: 40,
+            marginRight: 40,
+            paddingRight: 16,
+          }}
+        >
+          <Stack>
+            <span
+              style={{
+                fontWeight: "bold",
+                paddingLeft: 6,
+              }}
+            >
+              Filter by:
+            </span>
+            <SubFilter />
+          </Stack>
+          <RoomList />
+        </Stack>
+      </Stack>
+    </Container>
+  );
+}
+
+const MainFilter: React.FC<{}> = () => {
+  return (
+    <Stack
+      direction="row"
+      spacing={2}
+      divider={<Divider orientation="vertical" flexItem />}
+      style={{}}
+    >
+      <Building />
+      <Capacity />
+      <When />
+      <Duration />
+    </Stack>
+  );
+};
+
+const SearchBar: React.FC<{}> = () => {
+  return (
+    <Stack direction="row">
+      <MainFilter />
+      <SearchButton />
+    </Stack>
+  );
+};
+
+const SubFilter: React.FC<{}> = () => {
+  return (
+    <Stack
+      spacing={1}
+      divider={<Divider orientation="horizontal" flexItem />}
+      style={{
+        padding: 3,
+      }}
+    >
+      <RoomType />
+      <Location />
+      <IDRequired />
+    </Stack>
+  );
+};
+
+const RoomList: React.FC<{}> = () => {
+  return (
+    <Stack
+      style={{
+        borderStyle: "solid",
+        borderRadius: 3,
+        borderColor: "black",
+        borderWidth: "thin",
+        fontFamily: "Roboto",
+      }}
+    >
+      Ainsworth G03 Available Until 1:00pm
+    </Stack>
+  );
+};
+
+const Building: React.FC<{}> = () => {
+  return <Stack>Building</Stack>;
+};
+
+const Capacity: React.FC<{}> = () => {
+  return <Stack>Capacity</Stack>;
+};
+
+const When: React.FC<{}> = () => {
+  return <Stack>When</Stack>;
+};
+
+const Duration: React.FC<{}> = () => {
+  return <Stack>Duration</Stack>;
+};
+
+const SearchButton: React.FC<{}> = () => {
+  return (
+    <Stack>
+      <SearchIcon />
+    </Stack>
+  );
+};
+
+const RoomType: React.FC<{}> = () => {
+  return <Stack>Room Type</Stack>;
+};
+
+const Location: React.FC<{}> = () => {
+  return <Stack>Location</Stack>;
+};
+
+const IDRequired: React.FC<{}> = () => {
+  return <Stack>ID Required</Stack>;
+};
+
+const StyledSearchBar = styled(SearchBar)(({ theme }) => ({
+  minWidth: 0,
+  borderStyle: "solid",
+  borderRadius: 7,
+  borderColor: "black",
+  borderWidth: "thin",
+  marginTop: 48,
+  marginLeft: 32,
+  marginRight: 32,
+  marginBottom: 30,
+  padding: 10,
+  justifyContent: "space-between",
+}));

--- a/frontend/app/allRooms/page.tsx
+++ b/frontend/app/allRooms/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import ManageSearchIcon from "@mui/icons-material/ManageSearch";
+import SearchIcon from "@mui/icons-material/Search";
 import { useMediaQuery } from "@mui/material";
 import Container from "@mui/material/Container";
 import Stack from "@mui/material/Stack";
@@ -18,8 +18,7 @@ export default function Page() {
       <Stack>
         <StyledSearchBar>
           <AllRoomsSearchBar />
-          <ManageSearchIcon />
-          <></>
+          <SearchIcon />
         </StyledSearchBar>
 
         <StyledBody>
@@ -41,7 +40,7 @@ const StyledSearchBar = styled(Stack)(({ theme }) => ({
   borderStyle: "solid",
   borderWidth: "thin",
   borderColor: theme.palette.text.secondary,
-  margin: theme.spacing(6, 5, 3.75),
+  margin: theme.spacing(6, 6.25, 3.75),
   padding: theme.spacing(1.25),
   justifyContent: "space-between",
   alignItems: "center",
@@ -57,7 +56,7 @@ const StyledBody = styled(Stack)(({ theme }) => ({
   flexDirection: "row",
   flexWrap: "wrap",
   margin: theme.spacing(0, 4.25),
-  padding: theme.spacing(2.5),
+  padding: theme.spacing(2),
   justifyContent: "space-between",
 }));
 

--- a/frontend/components/AllRoomsFilter.tsx
+++ b/frontend/components/AllRoomsFilter.tsx
@@ -16,6 +16,7 @@ const AllRoomsFilter: React.FC<{}> = () => {
           marginRight: 2,
           fontWeight: 500,
           fontSize: "0.85rem",
+          paddingBottom: "4px",
         }}
       >
         FILTER OPTIONS

--- a/frontend/components/AllRoomsFilter.tsx
+++ b/frontend/components/AllRoomsFilter.tsx
@@ -1,0 +1,85 @@
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { styled } from "@mui/system";
+
+const AllRoomsFilter: React.FC<{}> = () => {
+  return (
+    <StyledMainFilter>
+      <Typography
+        sx={{
+          color: "primary.main",
+          fontWeight: 700,
+          fontFamily: "Josefin Sans",
+          width: "fit-content",
+          marginRight: 2,
+          backgroundColor: "green",
+          fontSize: { xs: "0.8rem", sm: "0.9rem", md: "1rem" },
+        }}
+      >
+        Filter by:
+      </Typography>
+      <Stack
+        sx={{
+          flexDirection: { xs: "row", sm: "row", md: "column" },
+        }}
+      >
+        <StyledAccordion>
+          <AccordionSummary expandIcon={<ArrowDropDownIcon />}>
+            {"Room type"}
+          </AccordionSummary>
+          <AccordionDetails>{"Auditorium"}</AccordionDetails>
+        </StyledAccordion>
+
+        <StyledAccordion>
+          <AccordionSummary expandIcon={<ArrowDropDownIcon />}>
+            {"Location"}
+          </AccordionSummary>
+          <AccordionDetails>{"Upper Campus"}</AccordionDetails>
+        </StyledAccordion>
+
+        <StyledAccordion>
+          <AccordionSummary expandIcon={<ArrowDropDownIcon />}>
+            {"ID Required"}
+          </AccordionSummary>
+          <AccordionDetails>{"Not Required"}</AccordionDetails>
+        </StyledAccordion>
+      </Stack>
+    </StyledMainFilter>
+  );
+};
+
+const StyledMainFilter = styled(Stack)(({ theme }) => ({
+  backgroundColor: "pink",
+  [theme.breakpoints.down("md")]: {
+    alignItems: "center",
+    flexDirection: "row",
+  },
+  [theme.breakpoints.up("md")]: {
+    alignItems: "stretch",
+    flexDirection: "column",
+  },
+}));
+
+const StyledAccordion = styled(Accordion)(({ theme }) => ({
+  backgroundColor: theme.palette.background.default,
+  boxShadow: "none",
+  "&.MuiAccordion-root:before": {
+    backgroundColor: theme.palette.background.default,
+    height: 0,
+  },
+  disableGutters: true,
+  [theme.breakpoints.down("xs")]: {
+    fontSize: "0.7em",
+    flexDirection: "row",
+  },
+  [theme.breakpoints.down("sm")]: {
+    fontSize: "0.8em",
+    flexDirection: "row",
+  },
+}));
+
+export default AllRoomsFilter;

--- a/frontend/components/AllRoomsFilter.tsx
+++ b/frontend/components/AllRoomsFilter.tsx
@@ -12,15 +12,13 @@ const AllRoomsFilter: React.FC<{}> = () => {
       <Typography
         sx={{
           color: "primary.main",
-          fontWeight: 700,
-          fontFamily: "Josefin Sans",
           width: "fit-content",
           marginRight: 2,
-          backgroundColor: "green",
-          fontSize: { xs: "0.8rem", sm: "0.9rem", md: "1rem" },
+          fontWeight: 500,
+          fontSize: "0.85rem",
         }}
       >
-        Filter by:
+        FILTER OPTIONS
       </Typography>
       <Stack
         sx={{
@@ -53,15 +51,9 @@ const AllRoomsFilter: React.FC<{}> = () => {
 };
 
 const StyledMainFilter = styled(Stack)(({ theme }) => ({
-  backgroundColor: "pink",
-  [theme.breakpoints.down("md")]: {
-    alignItems: "center",
-    flexDirection: "row",
-  },
-  [theme.breakpoints.up("md")]: {
-    alignItems: "stretch",
-    flexDirection: "column",
-  },
+  alignItems: "stretch",
+  flexDirection: "column",
+  flexGrow: 3,
 }));
 
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
@@ -72,14 +64,6 @@ const StyledAccordion = styled(Accordion)(({ theme }) => ({
     height: 0,
   },
   disableGutters: true,
-  [theme.breakpoints.down("xs")]: {
-    fontSize: "0.7em",
-    flexDirection: "row",
-  },
-  [theme.breakpoints.down("sm")]: {
-    fontSize: "0.8em",
-    flexDirection: "row",
-  },
 }));
 
 export default AllRoomsFilter;

--- a/frontend/components/AllRoomsFilterMobile.tsx
+++ b/frontend/components/AllRoomsFilterMobile.tsx
@@ -1,0 +1,70 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Drawer from "@mui/material/Drawer";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import * as React from "react";
+
+type Anchor = "bottom";
+
+export default function AnchorTemporaryDrawer() {
+  const [state, setState] = React.useState({
+    bottom: false,
+  });
+
+  const toggleDrawer =
+    (anchor: Anchor, open: boolean) =>
+    (event: React.KeyboardEvent | React.MouseEvent) => {
+      if (
+        event.type === "keydown" &&
+        ((event as React.KeyboardEvent).key === "Tab" ||
+          (event as React.KeyboardEvent).key === "Shift")
+      ) {
+        return;
+      }
+
+      setState({ ...state, [anchor]: open });
+    };
+
+  const list = (anchor: Anchor) => (
+    <Box
+      sx={{ width: anchor === "bottom" ? "auto" : 250 }}
+      role="filtering"
+      onClick={toggleDrawer(anchor, false)}
+      onKeyDown={toggleDrawer(anchor, false)}
+    >
+      <List>
+        {["Room type", "Location", "ID Required"].map((text) => (
+          <ListItem key={text} disablePadding>
+            <ListItemButton>
+              <ListItemText primary={text} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+
+  return (
+    <>
+      <Button
+        onClick={toggleDrawer("bottom", true)}
+        sx={{
+          fontWeight: 500,
+          fontSize: { xs: "0.8rem", sm: "0.9rem", md: "1rem" },
+        }}
+      >
+        FILTER OPTIONS
+      </Button>
+      <Drawer
+        anchor={"bottom"}
+        open={state["bottom"]}
+        onClose={toggleDrawer("bottom", false)}
+      >
+        {list("bottom")}
+      </Drawer>
+    </>
+  );
+}

--- a/frontend/components/AllRoomsFilterMobile.tsx
+++ b/frontend/components/AllRoomsFilterMobile.tsx
@@ -1,3 +1,4 @@
+import { Typography } from "@mui/material";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Drawer from "@mui/material/Drawer";
@@ -54,9 +55,19 @@ export default function AnchorTemporaryDrawer() {
         sx={{
           fontWeight: 500,
           fontSize: { xs: "0.8rem", sm: "0.9rem", md: "1rem" },
+          margin: 0,
         }}
       >
-        FILTER OPTIONS
+        <Typography
+          style={{
+            color: "primary.main",
+            width: "fit-content",
+            fontWeight: 500,
+            fontSize: "0.85rem",
+          }}
+        >
+          FILTER OPTIONS
+        </Typography>
       </Button>
       <Drawer
         anchor={"bottom"}

--- a/frontend/components/AllRoomsRoom.tsx
+++ b/frontend/components/AllRoomsRoom.tsx
@@ -1,0 +1,37 @@
+import { Typography } from "@mui/material";
+import Stack from "@mui/material/Stack";
+import { styled } from "@mui/system";
+
+const Room: React.FC<{
+  building: string;
+  string: string;
+}> = ({ building, string }) => {
+  return (
+    <>
+      <RoomDetails>
+        <Typography
+          sx={{
+            fontWeight: "bold",
+          }}
+        >
+          {building}
+        </Typography>
+        <Typography>{string}</Typography>
+      </RoomDetails>
+    </>
+  );
+};
+
+const RoomDetails = styled(Stack)(({ theme }) => ({
+  flexDirection: "row",
+  justifyContent: "space-between",
+  height: "fit-content",
+  borderRadius: 4,
+  borderStyle: "solid",
+  borderColor: "black",
+  borderWidth: "thin",
+  margin: theme.spacing(0, 1.25, 1.25, 1.25),
+  padding: theme.spacing(1.25, 2.5, 1.25, 2.25),
+}));
+
+export default Room;

--- a/frontend/components/AllRoomsRoom.tsx
+++ b/frontend/components/AllRoomsRoom.tsx
@@ -7,25 +7,23 @@ const Room: React.FC<{
   string: string;
 }> = ({ building, string }) => {
   return (
-    <>
-      <RoomDetails>
-        <Typography
-          sx={{
-            fontWeight: "bold",
-            fontSize: { sm: "0.9em", md: "0.95em" },
-          }}
-        >
-          {building}
-        </Typography>
-        <Typography
-          sx={{
-            fontSize: { sm: "0.9em", md: "0.95em" },
-          }}
-        >
-          {string}
-        </Typography>
-      </RoomDetails>
-    </>
+    <RoomDetails>
+      <Typography
+        sx={{
+          fontWeight: "bold",
+          fontSize: { sm: "0.9em", md: "0.95em" },
+        }}
+      >
+        {building}
+      </Typography>
+      <Typography
+        sx={{
+          fontSize: { sm: "0.9em", md: "0.95em" },
+        }}
+      >
+        {string}
+      </Typography>
+    </RoomDetails>
   );
 };
 
@@ -37,7 +35,7 @@ const RoomDetails = styled(Stack)(({ theme }) => ({
   borderStyle: "solid",
   borderColor: "black",
   borderWidth: "thin",
-  margin: theme.spacing(0, 1.25, 1.25, 1.25),
+  margin: theme.spacing(0, 0, 1.25),
   padding: theme.spacing(1.25, 2.5, 1.25, 2.25),
 }));
 

--- a/frontend/components/AllRoomsRoom.tsx
+++ b/frontend/components/AllRoomsRoom.tsx
@@ -12,11 +12,18 @@ const Room: React.FC<{
         <Typography
           sx={{
             fontWeight: "bold",
+            fontSize: { sm: "0.9em", md: "0.95em" },
           }}
         >
           {building}
         </Typography>
-        <Typography>{string}</Typography>
+        <Typography
+          sx={{
+            fontSize: { sm: "0.9em", md: "0.95em" },
+          }}
+        >
+          {string}
+        </Typography>
       </RoomDetails>
     </>
   );

--- a/frontend/components/AllRoomsRoomList.tsx
+++ b/frontend/components/AllRoomsRoomList.tsx
@@ -6,13 +6,13 @@ const RoomList = styled(Stack)(({ theme }) => ({
   flexGrow: 5,
   [theme.breakpoints.down("md")]: {
     width: "100%",
-    marginTop: 10,
+    marginTop: 14,
   },
   [theme.breakpoints.up("md")]: {
     width: "75%",
     marginLeft: 10,
+    marginTop: 8,
   },
-  backgroundColor: "blue",
 }));
 
 export default RoomList;

--- a/frontend/components/AllRoomsRoomList.tsx
+++ b/frontend/components/AllRoomsRoomList.tsx
@@ -1,0 +1,18 @@
+import Stack from "@mui/material/Stack";
+import { styled } from "@mui/system";
+
+const RoomList = styled(Stack)(({ theme }) => ({
+  flexDirection: "column",
+  flexGrow: 5,
+  [theme.breakpoints.down("md")]: {
+    width: "100%",
+    marginTop: 10,
+  },
+  [theme.breakpoints.up("md")]: {
+    width: "75%",
+    marginLeft: 10,
+  },
+  backgroundColor: "blue",
+}));
+
+export default RoomList;

--- a/frontend/components/AllRoomsSearchBar.tsx
+++ b/frontend/components/AllRoomsSearchBar.tsx
@@ -26,6 +26,7 @@ const Building: React.FC<{}> = () => {
         flexGrow: 1,
         maxWidth: "440px",
         fontSize: { xs: "0.9em", sm: "1em" },
+        fontWeight: 300,
       }}
     >
       Building
@@ -40,6 +41,7 @@ const Capacity: React.FC<{}> = () => {
         flexGrow: 1,
         maxWidth: "440px",
         fontSize: { xs: "0.9em", sm: "1em" },
+        fontWeight: 300,
       }}
     >
       Capacity
@@ -54,6 +56,7 @@ const When: React.FC<{}> = () => {
         flexGrow: 1,
         maxWidth: "440px",
         fontSize: { xs: "0.9em", sm: "1em" },
+        fontWeight: 300,
       }}
     >
       When
@@ -68,6 +71,7 @@ const Duration: React.FC<{}> = () => {
         flexGrow: 1,
         maxWidth: "440px",
         fontSize: { xs: "0.9em", sm: "1em" },
+        fontWeight: 300,
       }}
     >
       Duration

--- a/frontend/components/AllRoomsSearchBar.tsx
+++ b/frontend/components/AllRoomsSearchBar.tsx
@@ -1,0 +1,78 @@
+import Stack from "@mui/material/Stack";
+
+const AllRoomsSearchBar: React.FC<{}> = () => {
+  return (
+    <Stack
+      direction="row"
+      spacing={{ xs: 1, sm: 2 }}
+      sx={{
+        justifyContent: "center",
+        flexGrow: 3,
+      }}
+    >
+      <div></div>
+      <Building />
+      <Capacity />
+      <When />
+      <Duration />
+    </Stack>
+  );
+};
+
+const Building: React.FC<{}> = () => {
+  return (
+    <Stack
+      sx={{
+        flexGrow: 1,
+        maxWidth: "440px",
+        fontSize: { xs: "0.9em", sm: "1em" },
+      }}
+    >
+      Building
+    </Stack>
+  );
+};
+
+const Capacity: React.FC<{}> = () => {
+  return (
+    <Stack
+      sx={{
+        flexGrow: 1,
+        maxWidth: "440px",
+        fontSize: { xs: "0.9em", sm: "1em" },
+      }}
+    >
+      Capacity
+    </Stack>
+  );
+};
+
+const When: React.FC<{}> = () => {
+  return (
+    <Stack
+      sx={{
+        flexGrow: 1,
+        maxWidth: "440px",
+        fontSize: { xs: "0.9em", sm: "1em" },
+      }}
+    >
+      When
+    </Stack>
+  );
+};
+
+const Duration: React.FC<{}> = () => {
+  return (
+    <Stack
+      sx={{
+        flexGrow: 1,
+        maxWidth: "440px",
+        fontSize: { xs: "0.9em", sm: "1em" },
+      }}
+    >
+      Duration
+    </Stack>
+  );
+};
+
+export default AllRoomsSearchBar;

--- a/frontend/components/AllRoomsSearchBar.tsx
+++ b/frontend/components/AllRoomsSearchBar.tsx
@@ -10,7 +10,6 @@ const AllRoomsSearchBar: React.FC<{}> = () => {
         flexGrow: 3,
       }}
     >
-      <div></div>
       <Building />
       <Capacity />
       <When />
@@ -24,9 +23,10 @@ const Building: React.FC<{}> = () => {
     <Stack
       sx={{
         flexGrow: 1,
-        maxWidth: "440px",
+        maxWidth: "640px",
         fontSize: { xs: "0.9em", sm: "1em" },
         fontWeight: 300,
+        paddingLeft: { xs: "0px", sm: "8px" },
       }}
     >
       Building
@@ -39,7 +39,7 @@ const Capacity: React.FC<{}> = () => {
     <Stack
       sx={{
         flexGrow: 1,
-        maxWidth: "440px",
+        maxWidth: "320px",
         fontSize: { xs: "0.9em", sm: "1em" },
         fontWeight: 300,
       }}
@@ -54,7 +54,7 @@ const When: React.FC<{}> = () => {
     <Stack
       sx={{
         flexGrow: 1,
-        maxWidth: "440px",
+        maxWidth: "320px",
         fontSize: { xs: "0.9em", sm: "1em" },
         fontWeight: 300,
       }}
@@ -69,7 +69,7 @@ const Duration: React.FC<{}> = () => {
     <Stack
       sx={{
         flexGrow: 1,
-        maxWidth: "440px",
+        maxWidth: "320px",
         fontSize: { xs: "0.9em", sm: "1em" },
         fontWeight: 300,
       }}

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -3,7 +3,9 @@
 import { DarkMode } from "@mui/icons-material";
 import GridIcon from "@mui/icons-material/GridViewRounded";
 import MapIcon from "@mui/icons-material/Map";
+import MeetingRoomIcon from "@mui/icons-material/MeetingRoom";
 import SearchIcon from "@mui/icons-material/Search";
+
 import MuiAppBar from "@mui/material/AppBar";
 import { AppBarProps as MuiAppBarProps } from "@mui/material/AppBar/AppBar";
 import Stack from "@mui/material/Stack";
@@ -54,6 +56,13 @@ const NavBar: React.FC<NavBarProps> = ({ drawerOpen }) => {
           href="/browse"
         >
           <GridIcon />
+        </IconButton>
+        <IconButton
+          aria-label="All rooms"
+          active={path === "/allRooms"}
+          href="/allRooms"
+        >
+          <MeetingRoomIcon />
         </IconButton>
         <IconButton aria-label="Go to map" active={path === "/map"} href="/map">
           <MapIcon />

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -5,7 +5,6 @@ import GridIcon from "@mui/icons-material/GridViewRounded";
 import MapIcon from "@mui/icons-material/Map";
 import MeetingRoomIcon from "@mui/icons-material/MeetingRoom";
 import SearchIcon from "@mui/icons-material/Search";
-
 import MuiAppBar from "@mui/material/AppBar";
 import { AppBarProps as MuiAppBarProps } from "@mui/material/AppBar/AppBar";
 import Stack from "@mui/material/Stack";


### PR DESCRIPTION
### Overview
The new changes are as follows:
- A new page with three sections - main search bar, side filter, and a list of available rooms (just a skeleton)
- Icon at the top to navigate to that page
### How to view
To view these new changes, running the frontend would be sufficient enough.
### Changes
![freerooms_501_changes](https://github.com/user-attachments/assets/0fd29c88-1f7c-4e68-8099-f6c1db12f1d5)
![freerooms_501_changes_2](https://github.com/user-attachments/assets/a4ca9877-0487-4b42-8043-58e18c69979b)
![freerooms_501_changes_3](https://github.com/user-attachments/assets/76143539-a522-428d-b04c-0aa71db3ceb4)