### PR TITLE
505 feature click more for list of room blocks - Summary of PR

### DIFF
--- a/frontend/app/allRooms/page.tsx
+++ b/frontend/app/allRooms/page.tsx
@@ -2,11 +2,13 @@
 
 import SearchIcon from "@mui/icons-material/Search";
 import { useMediaQuery } from "@mui/material";
+import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Stack from "@mui/material/Stack";
 import { styled, useTheme } from "@mui/system";
 import useAllRooms from "hooks/useAllRooms";
 import { useMemo } from "react";
+import { useState } from "react";
 
 import AllRoomsFilter from "../../components/AllRoomsFilter";
 import AllRoomsFilterMobile from "../../components/AllRoomsFilterMobile";
@@ -16,9 +18,12 @@ import AllRoomsSearchBar from "../../components/AllRoomsSearchBar";
 
 export default function Page() {
   const { rooms, error } = useAllRooms();
+  const [visibleRooms, setVisibleRooms] = useState(20);
+
   const roomsDisplay = useMemo(() => {
     if (!rooms) return;
-    return Object.entries(rooms).map(([roomId, { name, status, endtime }]) => {
+    const roomEntries = Object.entries(rooms).slice(0, visibleRooms);
+    return roomEntries.map(([roomId, { name, status, endtime }]) => {
       return (
         <Room
           key={roomId}
@@ -29,7 +34,13 @@ export default function Page() {
         />
       );
     });
-  }, [rooms]);
+  }, [rooms, visibleRooms]);
+
+  const handleLoadMore = () => {
+    setVisibleRooms((prev) => prev + 20);
+  };
+
+  const totalRooms = rooms ? Object.keys(rooms).length : 0;
 
   return (
     <Container>
@@ -40,7 +51,14 @@ export default function Page() {
         </StyledSearchBar>
         <StyledBody>
           <Filter />
-          <RoomList>{roomsDisplay}</RoomList>
+          <RoomList>
+            {roomsDisplay}
+            {visibleRooms < totalRooms && (
+              <Button variant="contained" onClick={handleLoadMore}>
+                Load More Rooms
+              </Button>
+            )}
+          </RoomList>
         </StyledBody>
       </Stack>
     </Container>


### PR DESCRIPTION
**Changes I've made** 
Added a "load more rooms" button to the all rooms list 

- it scrolls with the list of rooms so it only appears when u reach the end of the list
- when there are no more rooms to show the button should disappear 
- darkens when you hover over it 
- orange in line with the freerooms theme

<img width="886" alt="Screenshot 2024-10-14 at 7 57 25 PM" src="https://github.com/user-attachments/assets/6a02625a-312e-4776-ad0f-2c0f74801b54">
<img width="900" alt="Screenshot 2024-10-14 at 7 57 07 PM" src="https://github.com/user-attachments/assets/7c842aa5-8e33-4856-8dc3-17ee91241cf0">
