### PR TITLE
855 - locking AEST time to frontend

### DIFF
--- a/frontend/__tests__/AllRoomsPage.test.tsx
+++ b/frontend/__tests__/AllRoomsPage.test.tsx
@@ -9,6 +9,7 @@ import Room from "../components/AllRoomsRoom";
 import AllRoomsSearchBar from "../components/AllRoomsSearchBar";
 import NavBar from "../components/NavBar";
 import store from "../redux/store";
+import toSydneyTime from "../utils/toSydneyTime";
 import renderWithRedux from "./utils/renderWithRedux";
 
 // Mock DarkModeContext to avoid test failing due to importing NuqsAdapter
@@ -97,7 +98,7 @@ describe("AllRooms page", () => {
     it("renders AllRoomsRoom - Available", () => {
       const roomStatus = {
         status: "free" as const,
-        endtime: new Date().toISOString(),
+        endtime: toSydneyTime(new Date()).toISOString(),
       };
 
       render(
@@ -116,7 +117,7 @@ describe("AllRooms page", () => {
     it("renders AllRoomsRoom - Unavailable", () => {
       const roomStatus = {
         status: "busy" as const,
-        endtime: new Date().toISOString(),
+        endtime: toSydneyTime(new Date()).toISOString(),
       };
 
       render(
@@ -135,7 +136,7 @@ describe("AllRooms page", () => {
     it("renders AllRoomsRoom - Available Soon", () => {
       const roomStatus = {
         status: "soon" as const,
-        endtime: new Date().toISOString(),
+        endtime: toSydneyTime(new Date()).toISOString(),
       };
 
       render(

--- a/frontend/__tests__/BookingCalendar.test.tsx
+++ b/frontend/__tests__/BookingCalendar.test.tsx
@@ -7,6 +7,7 @@ import { Provider } from "react-redux";
 
 import BookingCalendar from "../components/BookingCalendar";
 import store from "../redux/store";
+import toSydneyTime from "../utils/toSydneyTime";
 
 // Ref: https://stackoverflow.com/questions/56180772/jest-material-ui-correctly-mocking-usemediaquery
 function createMatchMedia(width: number) {
@@ -22,8 +23,8 @@ function createMatchMedia(width: number) {
   });
 }
 
-const start: Date = new Date();
-const end: Date = new Date();
+const start: Date = toSydneyTime(new Date());
+const end: Date = toSydneyTime(new Date());
 const events: Booking[] = [
   {
     name: "MARK5827 TUT",

--- a/frontend/__tests__/RoomAvailabilityBox.test.tsx
+++ b/frontend/__tests__/RoomAvailabilityBox.test.tsx
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 
+import toSydneyTime from "../utils/toSydneyTime";
 import RoomAvailabilityBox from "../views/RoomAvailabilityBox";
 
 jest.mock("../public/room-photos.json", () => ({
@@ -14,7 +15,7 @@ jest.mock("../public/room-photos.json", () => ({
 
 const roomStatus = {
   status: "soon" as const,
-  endtime: new Date().toISOString(),
+  endtime: toSydneyTime(new Date()).toISOString(),
 };
 
 describe("RoomAvailabilityBox", () => {
@@ -22,7 +23,7 @@ describe("RoomAvailabilityBox", () => {
     // Mock roomStatus representing "available soon" status
     const roomStatus = {
       status: "soon" as const,
-      endtime: new Date().toISOString(),
+      endtime: toSydneyTime(new Date()).toISOString(),
     };
 
     // Render RoomAvailabilityBox with mock data

--- a/frontend/components/AllRoomsSearchBar.tsx
+++ b/frontend/components/AllRoomsSearchBar.tsx
@@ -7,10 +7,11 @@ import {
 } from "@mui/x-date-pickers";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { enAU } from "date-fns/locale";
+import { fromZonedTime } from "date-fns-tz";
 
 import { selectDatetime, setDatetime } from "../redux/datetimeSlice";
 import { useDispatch, useSelector } from "../redux/hooks";
-import toSydneyTime from "../utils/toSydneyTime";
+import { SYDNEY_TIMEZONE } from "../utils/toSydneyTime";
 
 export default function AllRoomsSearchBar() {
   const dispatch = useDispatch();
@@ -37,7 +38,8 @@ export default function AllRoomsSearchBar() {
           value={datetime}
           sx={{ flex: 1 }}
           onChange={(value: Date | null) =>
-            value && dispatch(setDatetime(toSydneyTime(value)))
+            value &&
+            dispatch(setDatetime(fromZonedTime(value, SYDNEY_TIMEZONE)))
           }
         />
         <TimePicker
@@ -45,7 +47,8 @@ export default function AllRoomsSearchBar() {
           defaultValue={datetime}
           sx={{ flex: 1 }}
           onAccept={(value: Date | null) =>
-            value && dispatch(setDatetime(toSydneyTime(value)))
+            value &&
+            dispatch(setDatetime(fromZonedTime(value, SYDNEY_TIMEZONE)))
           }
         />
       </LocalizationProvider>

--- a/frontend/components/BookingCalendar.tsx
+++ b/frontend/components/BookingCalendar.tsx
@@ -18,8 +18,9 @@ import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
-import { format, getDay, isToday, parse, startOfWeek } from "date-fns";
+import { format, getDay, isSameDay, parse, startOfWeek } from "date-fns";
 import { enAU } from "date-fns/locale";
+import { toZonedTime } from "date-fns-tz";
 import React from "react";
 import type { DateRange, View } from "react-big-calendar";
 import type { NavigateAction, ToolbarProps } from "react-big-calendar";
@@ -272,6 +273,13 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
 
   const timeInDay = 24 * 60 * 60 * 1000;
 
+  // Render light / dark background based on whether today is in AEST time
+  const isTodaySydney = (date: Date) =>
+    isSameDay(
+      toZonedTime(date, "Australia/Sydney"),
+      toZonedTime(new Date(), "Australia/Sydney")
+    );
+
   return (
     <Stack
       sx={{
@@ -390,7 +398,7 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
           slotGroupPropGetter={() => ({ style: { minHeight: "50px" } })}
           dayPropGetter={(date) => ({
             style: {
-              backgroundColor: isToday(date)
+              backgroundColor: isTodaySydney(date)
                 ? theme.palette.mode === "light"
                   ? "#fff3e0"
                   : grey[900]

--- a/frontend/components/BookingCalendar.tsx
+++ b/frontend/components/BookingCalendar.tsx
@@ -32,6 +32,7 @@ import {
 
 import { selectDatetime } from "../redux/datetimeSlice";
 import { useSelector } from "../redux/hooks";
+import toSydneyTime from "../utils/toSydneyTime";
 
 const ToolBarButton = styled(Button)(({ theme }) => ({
   borderColor: theme.palette.secondary.main,
@@ -217,7 +218,7 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
         components: {
           toolbar: CustomToolBar,
         },
-        getNow: () => new Date(),
+        getNow: () => toSydneyTime(new Date()),
         localizer: dateFnsLocalizer({
           format,
           parse,

--- a/frontend/components/BookingCalendar.tsx
+++ b/frontend/components/BookingCalendar.tsx
@@ -20,7 +20,6 @@ import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { format, getDay, isSameDay, parse, startOfWeek } from "date-fns";
 import { enAU } from "date-fns/locale";
-import { toZonedTime } from "date-fns-tz";
 import React from "react";
 import type { DateRange, View } from "react-big-calendar";
 import type { NavigateAction, ToolbarProps } from "react-big-calendar";
@@ -171,7 +170,7 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
   const currView = isMobile ? Views.DAY : desktopView;
 
   const datetime = useSelector(selectDatetime);
-  const [date, setDate] = React.useState<Date>(datetime);
+  const [date, setDate] = React.useState<Date>(() => toSydneyTime(datetime));
 
   const handleDateChange = (newDate: Date | null) => {
     setDate(newDate ?? datetime);
@@ -181,7 +180,13 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
     const DEFAULT_START_HOUR = 9;
     const EARLIEST_ALLOWED_HOUR = 5;
 
-    const visibleEvents = events.filter((event) => {
+    const sydneyEvents = events.map((event) => ({
+      ...event,
+      start: toSydneyTime(event.start),
+      end: toSydneyTime(event.end),
+    }));
+
+    const visibleEvents = sydneyEvents.filter((event) => {
       if (currView === Views.DAY) {
         return (
           event.start.getFullYear() === date.getFullYear() &&
@@ -227,7 +232,11 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
           getDay,
           locales: enAU,
         }),
-        myEvents: events,
+        myEvents: events.map((event) => ({
+          ...event,
+          start: toSydneyTime(event.start),
+          end: toSydneyTime(event.end),
+        })),
         scrollToTime: calendarMin,
       };
     }, [events, calendarMin]);
@@ -273,12 +282,9 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
 
   const timeInDay = 24 * 60 * 60 * 1000;
 
-  // Render light / dark background based on whether today is in AEST time
+  // Render light / dark background based on whether today is in Sydney time.
   const isTodaySydney = (date: Date) =>
-    isSameDay(
-      toZonedTime(date, "Australia/Sydney"),
-      toZonedTime(new Date(), "Australia/Sydney")
-    );
+    isSameDay(date, toSydneyTime(new Date()));
 
   return (
     <Stack

--- a/frontend/components/DatePicker.tsx
+++ b/frontend/components/DatePicker.tsx
@@ -5,11 +5,12 @@ import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { DesktopDatePicker } from "@mui/x-date-pickers/DesktopDatePicker";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { enAU } from "date-fns/locale";
+import { fromZonedTime, toZonedTime } from "date-fns-tz";
 import React from "react";
 
 import { selectDatetime, setDatetime } from "../redux/datetimeSlice";
 import { useDispatch, useSelector } from "../redux/hooks";
-import toSydneyTime from "../utils/toSydneyTime";
+import { SYDNEY_TIMEZONE } from "../utils/toSydneyTime";
 
 const DatePicker = () => {
   const dispatch = useDispatch();
@@ -20,9 +21,9 @@ const DatePicker = () => {
     <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={enAU}>
       <DesktopDatePicker
         format="dd/MM/yy"
-        value={datetime}
+        value={toZonedTime(datetime, SYDNEY_TIMEZONE)}
         onChange={(value: Date | null) =>
-          value && dispatch(setDatetime(toSydneyTime(value)))
+          value && dispatch(setDatetime(fromZonedTime(value, SYDNEY_TIMEZONE)))
         }
         sx={{
           width: 133,

--- a/frontend/components/TimePicker.tsx
+++ b/frontend/components/TimePicker.tsx
@@ -5,11 +5,12 @@ import { DesktopTimePicker } from "@mui/x-date-pickers";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { enAU } from "date-fns/locale";
+import { fromZonedTime, toZonedTime } from "date-fns-tz";
 import React from "react";
 
 import { selectDatetime, setDatetime } from "../redux/datetimeSlice";
 import { useDispatch, useSelector } from "../redux/hooks";
-import toSydneyTime from "../utils/toSydneyTime";
+import { SYDNEY_TIMEZONE } from "../utils/toSydneyTime";
 
 const TimePicker = () => {
   const dispatch = useDispatch();
@@ -19,9 +20,9 @@ const TimePicker = () => {
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={enAU}>
       <DesktopTimePicker
-        value={datetime}
+        value={toZonedTime(datetime, SYDNEY_TIMEZONE)}
         onChange={(value: Date | null) =>
-          value && dispatch(setDatetime(toSydneyTime(value)))
+          value && dispatch(setDatetime(fromZonedTime(value, SYDNEY_TIMEZONE)))
         }
         format="hh:mm a"
         slotProps={{

--- a/frontend/hooks/useDateTimeQuery.ts
+++ b/frontend/hooks/useDateTimeQuery.ts
@@ -1,8 +1,10 @@
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useRef } from "react";
 import { selectDatetime, setDatetime } from "redux/datetimeSlice";
 
 import { useDispatch, useSelector } from "../redux/hooks";
+import { SYDNEY_TIMEZONE } from "../utils/toSydneyTime";
 
 const isValidDate = (date: string): boolean => {
   // Valid format is YYYY-MM-DD
@@ -49,28 +51,10 @@ const useQueryDatetime = () => {
       setDatetimeParams(invalidKeys);
     }
 
-    // Construct new Date object in UTC format from query parameters to Redux state
+    // Construct datetime string in Sydney time to store in Redux
     if ((date && isValidDate(date)) || (time && isValidTime(time))) {
-      const updateDate = new Date(datetime);
-
-      // Get the actual date in UTC format
-      if (date && isValidDate(date)) {
-        const currentDate = new Date(date);
-        updateDate.setFullYear(
-          currentDate.getFullYear(),
-          currentDate.getMonth(),
-          currentDate.getDate()
-        );
-      }
-
-      // Get the actual time in UTC format
-      if (time && isValidTime(time)) {
-        const [hours, minutes] = time.split(":").map(Number);
-        updateDate.setHours(hours, minutes, 0, 0);
-      }
-
-      // Update Redux datetime
-      dispatch(setDatetime(updateDate));
+      const sydneyDate = `${date || formatInTimeZone(datetime, SYDNEY_TIMEZONE, "yyyy-MM-dd")}T${time || formatInTimeZone(datetime, SYDNEY_TIMEZONE, "HH:mm")}:00`;
+      dispatch(setDatetime(fromZonedTime(sydneyDate, SYDNEY_TIMEZONE)));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
@@ -84,12 +68,14 @@ const useQueryDatetime = () => {
 
     // Set date to YYYY-MM-DD format
     const date =
-      datetime instanceof Date ? datetime.toISOString().split("T")[0] : null;
+      datetime instanceof Date
+        ? formatInTimeZone(datetime, SYDNEY_TIMEZONE, "yyyy-MM-dd")
+        : null;
 
     // Set time to HH:MM format
     const time =
       datetime instanceof Date
-        ? `${String(datetime.getHours()).padStart(2, "0")}:${String(datetime.getMinutes()).padStart(2, "0")}`
+        ? formatInTimeZone(datetime, SYDNEY_TIMEZONE, "HH:mm")
         : null;
 
     setDatetimeParams({ date, time });

--- a/frontend/redux/datetimeSlice.ts
+++ b/frontend/redux/datetimeSlice.ts
@@ -3,6 +3,7 @@
  */
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
+import toSydneyTime from "../utils/toSydneyTime";
 import { RootState } from "./store";
 
 interface DatetimeSlice {
@@ -10,7 +11,7 @@ interface DatetimeSlice {
 }
 
 const initialState: DatetimeSlice = {
-  value: new Date(),
+  value: toSydneyTime(new Date()),
 };
 
 const datetimeSlice = createSlice({

--- a/frontend/redux/datetimeSlice.ts
+++ b/frontend/redux/datetimeSlice.ts
@@ -3,7 +3,6 @@
  */
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-import toSydneyTime from "../utils/toSydneyTime";
 import { RootState } from "./store";
 
 interface DatetimeSlice {
@@ -11,7 +10,7 @@ interface DatetimeSlice {
 }
 
 const initialState: DatetimeSlice = {
-  value: toSydneyTime(new Date()),
+  value: new Date(),
 };
 
 const datetimeSlice = createSlice({

--- a/frontend/utils/toSydneyTime.ts
+++ b/frontend/utils/toSydneyTime.ts
@@ -1,25 +1,12 @@
-import { getTimezoneOffset } from "date-fns-tz";
+import { toZonedTime } from "date-fns-tz";
 
-const USER_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+export const SYDNEY_TIMEZONE = "Australia/Sydney";
 
 /**
- * Take a Date created in local time and converts it to Sydney time.
- *
- * The conversion logic may look a little backwards, but consider that a time in
- * UTC+10 actually occurs 10 hours before the same time in UTC. So, to convert
- * from 6PM UTC to 6PM AEST we need to subtract 10 hours.
- *
- * Example:
- *  We've created a Date at 6PM in the local TZ, say UTC-4 - this is 10PM UTC.
- *  This function will convert it to 6PM Sydney time i.e. 8AM UTC.
- *  We do this by adding -4 (local offset) and subtracting 10 (syd offset) hours
+ * Convert given time to Sydney time zone
  */
 const toSydneyTime = (date: Date): Date => {
-  const sydOffset = getTimezoneOffset("Australia/Sydney", date);
-  const userOffset = getTimezoneOffset(USER_TZ, date);
-
-  // Add user offset to force UTC then subtract syd offset to force Sydney time
-  return new Date(date.getTime() + userOffset - sydOffset);
+  return toZonedTime(date, SYDNEY_TIMEZONE);
 };
 
 export default toSydneyTime;


### PR DESCRIPTION
## What

Changes include:
- modifying the existing `utils/toSydneyTime` implementation to convert time from Redux to Sydney
- pages that display time will have their time converted to Sydney time before displaying
  - AllRoomsSearchBar.tsx, BookingCalendar.tsx, DatePicker, TimePicker
- query date and time hook was modified to display Sydney time onto URL

## Why

If the user were in Freerooms website and in a different region, the pages that depended on the user's local time would not take Sydney time, which messes with the page's contents. 

## How

Replaced instances of `new Date()` to be wrapped in `toSydneyTime()`. Modified existing test cases to also use locked Sydney time. Decided that wrapping `new Date()` in `toSydneyTime()` was not it. Decided to store the user's local time in Redux state, then only convert to Sydney time when displaying the time. 

## Screenshot / Recording

### Before
<img width="590" height="277" alt="image" src="https://github.com/user-attachments/assets/71460ba9-6c7f-438d-9231-5fb020f4a054" />
<img width="457" height="209" alt="image" src="https://github.com/user-attachments/assets/e7347560-7833-45a9-9d6c-6721042813fa" />

### After
Bit of delay in my ss...
<img width="596" height="270" alt="image" src="https://github.com/user-attachments/assets/9dcaa85d-24c3-4400-b407-86e6383ed998" />
<img width="457" height="209" alt="image" src="https://github.com/user-attachments/assets/4ee75589-4d2c-4fa2-9cc2-a02c167e640a" />

