### PR TITLE
Query Strings for Date and View on Rooms Page

### DIFF
--- a/frontend/__tests__/AllRoomsPage.test.tsx
+++ b/frontend/__tests__/AllRoomsPage.test.tsx
@@ -168,4 +168,48 @@ describe("AllRooms page", () => {
       expect(enterTime).not.toHaveValue("01:00 PM");
     });
   });
+
+  it("room link includes selected date", () => {
+    const roomStatus = {
+      status: "free" as const,
+      endtime: toSydneyTime(new Date()).toISOString(),
+    };
+
+    render(
+      <ThemeProvider theme={createTheme({})}>
+        <Room
+          name="Ainsworth G03"
+          roomNumber="K-H13-1003"
+          date="2026-09-16"
+          {...roomStatus}
+        />
+      </ThemeProvider>
+    );
+
+    const room = screen.getByRole("link");
+
+    expect(room).toHaveAttribute("href", "/room/K-H13-1003?date=2026-09-16");
+  });
+
+  it("room link does not include invalid date", () => {
+    const roomStatus = {
+      status: "free" as const,
+      endtime: toSydneyTime(new Date()).toISOString(),
+    };
+
+    render(
+      <ThemeProvider theme={createTheme({})}>
+        <Room
+          name="Ainsworth G03"
+          roomNumber="K-H13-1003"
+          date="invalid-date"
+          {...roomStatus}
+        />
+      </ThemeProvider>
+    );
+
+    const room = screen.getByRole("link");
+
+    expect(room).toHaveAttribute("href", "/room/K-H13-1003");
+  });
 });

--- a/frontend/__tests__/BookingCalendar.test.tsx
+++ b/frontend/__tests__/BookingCalendar.test.tsx
@@ -9,6 +9,15 @@ import BookingCalendar from "../components/BookingCalendar";
 import store from "../redux/store";
 import toSydneyTime from "../utils/toSydneyTime";
 
+const mockUseQueryStates = jest.fn();
+
+jest.mock("nuqs", () => ({
+  useQueryStates: (...args: unknown[]) => mockUseQueryStates(...args),
+  parseAsString: {
+    withDefault: (defaultValue: string) => ({ defaultValue }),
+  },
+}));
+
 // Ref: https://stackoverflow.com/questions/56180772/jest-material-ui-correctly-mocking-usemediaquery
 function createMatchMedia(width: number) {
   return (query: string): MediaQueryList => ({
@@ -33,6 +42,18 @@ const events: Booking[] = [
     end: end,
   },
 ];
+
+beforeEach(() => {
+  window.matchMedia = createMatchMedia(1024);
+
+  mockUseQueryStates.mockReturnValue([
+    {
+      view: "week",
+      date: "",
+    },
+    jest.fn(),
+  ]);
+});
 
 describe("Booking Calendar Desktop", () => {
   it("renders the calendar", () => {
@@ -61,6 +82,46 @@ describe("Booking Calendar Desktop", () => {
 
     expect(beforeButton).not.toBeInTheDocument();
     expect(nextButton).not.toBeInTheDocument();
+  });
+
+  it("uses date from query parameters", () => {
+    mockUseQueryStates.mockReturnValue([
+      {
+        view: "week",
+        date: "2026-09-11",
+      },
+      jest.fn(),
+    ]);
+
+    render(
+      <Provider store={store}>
+        <BookingCalendar events={events} roomID="test-room" />
+      </Provider>
+    );
+
+    const datePicker = screen.getByDisplayValue("Fri, 11 Sep 2026");
+
+    expect(datePicker).toBeInTheDocument();
+  });
+
+  it("uses view from query parameters", () => {
+    mockUseQueryStates.mockReturnValue([
+      {
+        view: "day",
+        date: "2026-09-11",
+      },
+      jest.fn(),
+    ]);
+
+    render(
+      <Provider store={store}>
+        <BookingCalendar events={events} roomID="test-room" />
+      </Provider>
+    );
+
+    const dayButton = screen.getByRole("button", { name: "Day" });
+
+    expect(dayButton).toHaveClass("rbc-active");
   });
 });
 

--- a/frontend/__tests__/BookingCalendar.test.tsx
+++ b/frontend/__tests__/BookingCalendar.test.tsx
@@ -121,7 +121,7 @@ describe("Booking Calendar Desktop", () => {
 
     const dayButton = screen.getByRole("button", { name: "Day" });
 
-    expect(dayButton).toHaveClass("rbc-active");
+    expect(dayButton).toHaveAttribute("aria-pressed", "true");
   });
 });
 

--- a/frontend/__tests__/BrowsingPage.test.tsx
+++ b/frontend/__tests__/BrowsingPage.test.tsx
@@ -31,7 +31,7 @@ jest.mock("nuqs", () => ({
   },
 }));
 
-jest.mock("views/BuildingDrawer", () => ({
+jest.mock("../views/BuildingDrawer", () => ({
   __esModule: true,
   default: ({ date }: { date?: string }) => (
     <div data-testid="building-drawer" data-date={date} />

--- a/frontend/__tests__/BrowsingPage.test.tsx
+++ b/frontend/__tests__/BrowsingPage.test.tsx
@@ -15,11 +15,11 @@ jest.mock("next/navigation", () => ({
 }));
 
 // Mock nuqs
+const mockUseQueryState = jest.fn();
+
 jest.mock("nuqs", () => ({
-  useQueryState: (_key: string, options: { defaultValue: string }) => [
-    options.defaultValue,
-    jest.fn(),
-  ],
+  useQueryState: (key: string, options: { defaultValue: string }) =>
+    mockUseQueryState(key, options),
   useQueryStates: (keys: Record<string, { defaultValue: string }>) => [
     Object.fromEntries(
       Object.entries(keys).map(([key, options]) => [key, options.defaultValue])
@@ -31,7 +31,23 @@ jest.mock("nuqs", () => ({
   },
 }));
 
+jest.mock("views/BuildingDrawer", () => ({
+  __esModule: true,
+  default: ({ date }: { date?: string }) => (
+    <div data-testid="building-drawer" data-date={date} />
+  ),
+}));
+
 describe("Browsing Page", () => {
+  beforeEach(() => {
+    mockUseQueryState.mockImplementation(
+      (_key: string, options: { defaultValue: string }) => [
+        options.defaultValue,
+        jest.fn(),
+      ]
+    );
+  });
+
   it("renders DesktopTimePicker", () => {
     render(
       <Provider store={store}>
@@ -49,5 +65,24 @@ describe("Browsing Page", () => {
 
     expect(timePicker).toBeInTheDocument();
     expect(datePicker).toBeInTheDocument();
+  });
+
+  it("passes selected date to BuildingDrawer", () => {
+    mockUseQueryState.mockImplementation(
+      (key: string, options: { defaultValue: string }) => [
+        key === "date" ? "2026-09-11" : options.defaultValue,
+        jest.fn(),
+      ]
+    );
+
+    render(
+      <Provider store={store}>
+        <Page />
+      </Provider>
+    );
+
+    const buildingDrawer = screen.getByTestId("building-drawer");
+
+    expect(buildingDrawer).toHaveAttribute("data-date", "2026-09-11");
   });
 });

--- a/frontend/__tests__/FavouriteButton.test.tsx
+++ b/frontend/__tests__/FavouriteButton.test.tsx
@@ -7,6 +7,18 @@ import { Provider } from "react-redux";
 
 import Page from "../app/room/[room]/page";
 
+jest.mock("nuqs", () => ({
+  useQueryStates: (keys: Record<string, { defaultValue: string }>) => [
+    Object.fromEntries(
+      Object.entries(keys).map(([key, options]) => [key, options.defaultValue])
+    ),
+    jest.fn(),
+  ],
+  parseAsString: {
+    withDefault: (defaultValue: string) => ({ defaultValue }),
+  },
+}));
+
 jest.mock("next/navigation", () => ({
   useParams: jest.fn(),
   useRouter: jest.fn(),

--- a/frontend/__tests__/RatingStar.test.tsx
+++ b/frontend/__tests__/RatingStar.test.tsx
@@ -13,6 +13,18 @@ import store from "../redux/store";
 import RoomAvailabilityBox from "../views/RoomAvailabilityBox";
 import renderWithRedux from "./utils/renderWithRedux";
 
+jest.mock("nuqs", () => ({
+  useQueryStates: (keys: Record<string, { defaultValue: string }>) => [
+    Object.fromEntries(
+      Object.entries(keys).map(([key, options]) => [key, options.defaultValue])
+    ),
+    jest.fn(),
+  ],
+  parseAsString: {
+    withDefault: (defaultValue: string) => ({ defaultValue }),
+  },
+}));
+
 jest.mock("next/navigation", () => ({
   useParams: jest.fn(),
   useRouter: jest.fn(),

--- a/frontend/__tests__/RoomAvailabilityBox.test.tsx
+++ b/frontend/__tests__/RoomAvailabilityBox.test.tsx
@@ -37,9 +37,7 @@ describe("RoomAvailabilityBox", () => {
 
     const availableSoonText = screen.getByText(/available soon/i);
     expect(availableSoonText).toBeInTheDocument();
-    // check if there is wrapping of the text, if offsetWidth < scrollWidth,
-    // then there is wrapping involved because the total width of the content
-    // is overflowing (i.e. some of the content is not visible)
+
     const isWrapping =
       availableSoonText.offsetWidth < availableSoonText.scrollWidth;
     expect(isWrapping).toBe(false);
@@ -75,5 +73,35 @@ describe("RoomAvailabilityBox", () => {
       getComputedStyle(box).getPropertyValue("background-image");
 
     expect(backgroundImage).toContain("/assets/building_photos/K-G14.webp");
+  });
+
+  test("room link includes selected date", () => {
+    render(
+      <RoomAvailabilityBox
+        roomNumber="334"
+        buildingId="K-G14"
+        roomStatus={roomStatus}
+        date="2026-09-11"
+      />
+    );
+
+    const link = screen.getByRole("link");
+
+    expect(link).toHaveAttribute("href", "/room/K-G14-334?date=2026-09-11");
+  });
+
+  test("room link does not include invalid date", () => {
+    render(
+      <RoomAvailabilityBox
+        roomNumber="334"
+        buildingId="K-G14"
+        roomStatus={roomStatus}
+        date="invalid-date"
+      />
+    );
+
+    const link = screen.getByRole("link");
+
+    expect(link).toHaveAttribute("href", "/room/K-G14-334");
   });
 });

--- a/frontend/app/allRooms/page.tsx
+++ b/frontend/app/allRooms/page.tsx
@@ -5,6 +5,7 @@ import Stack from "@mui/material/Stack";
 import { styled } from "@mui/system";
 import AllRoomsSearchBar from "components/AllRoomsSearchBar";
 import useAllRooms from "hooks/useAllRooms";
+import { parseAsString, useQueryState } from "nuqs";
 import { Suspense, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { selectAllRoomsFilters } from "redux/allRoomsFilterSlice";
@@ -18,6 +19,7 @@ function AllRoomsContent() {
   const filters = useSelector(selectAllRoomsFilters);
   const { rooms, isValidating } = useAllRooms(filters);
   const [visibleRooms, setVisibleRooms] = useState(20);
+  const [date] = useQueryState("date", parseAsString.withDefault(""));
 
   const roomsDisplay = useMemo(() => {
     if (!rooms) return;
@@ -43,10 +45,11 @@ function AllRoomsContent() {
           name={name}
           status={status}
           endtime={endtime}
+          date={date}
         />
       );
     });
-  }, [rooms, visibleRooms]);
+  }, [rooms, visibleRooms, date]);
 
   const handleLoadMore = () => {
     setVisibleRooms((prev) => prev + 20);

--- a/frontend/app/browse/page.tsx
+++ b/frontend/app/browse/page.tsx
@@ -6,6 +6,7 @@ import { styled } from "@mui/material/styles";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { enAU } from "date-fns/locale";
+import { parseAsString, useQueryState } from "nuqs";
 import React, { Suspense } from "react";
 import BuildingDrawer from "views/BuildingDrawer";
 
@@ -21,6 +22,7 @@ import CardList from "../../views/CardList";
 const BrowseContent = () => {
   const [sort, setSort] = useQuerySort();
   const [query, setQuery] = React.useState<string>("");
+  const [date] = useQueryState("date", parseAsString.withDefault(""));
 
   return (
     <Container maxWidth={false}>
@@ -73,7 +75,7 @@ const BrowseContent = () => {
           <CardList sort={sort} query={query} />
         </Tiles>
       </LocalizationProvider>
-      <BuildingDrawer />
+      <BuildingDrawer date={date} />
     </Container>
   );
 };

--- a/frontend/components/AllRoomsRoom.tsx
+++ b/frontend/components/AllRoomsRoom.tsx
@@ -10,16 +10,19 @@ import {
 import { RoomAvailabilityBoxProps } from "views/RoomAvailabilityBox";
 
 import RoomAvailability from "./RoomAvailability";
+import getRoomHref from "@frontend/utils/getRoomHref";
 
 type AllRoomsRoomProps = SearchResponseValue &
-  Pick<RoomAvailabilityBoxProps, "roomNumber">;
+  Pick<RoomAvailabilityBoxProps, "roomNumber" | "date">;
 
 const Room: React.FC<AllRoomsRoomProps> = ({
   name,
   roomNumber,
+  date,
   ...roomStatus
 }) => {
   const theme = useTheme();
+  const roomHref = getRoomHref(roomNumber, date);
 
   return (
     <Card
@@ -30,7 +33,7 @@ const Room: React.FC<AllRoomsRoomProps> = ({
         overflow: "visible",
       }}
     >
-      <CardActionArea href={`/room/${roomNumber}`} target="_blank">
+      <CardActionArea href={roomHref} target="_blank">
         <CardContent>
           <Stack
             direction="row"

--- a/frontend/components/AllRoomsRoom.tsx
+++ b/frontend/components/AllRoomsRoom.tsx
@@ -1,4 +1,5 @@
 import { SearchResponseValue } from "@common/types";
+import getRoomHref from "@frontend/utils/getRoomHref";
 import {
   Card,
   CardActionArea,
@@ -10,7 +11,6 @@ import {
 import { RoomAvailabilityBoxProps } from "views/RoomAvailabilityBox";
 
 import RoomAvailability from "./RoomAvailability";
-import getRoomHref from "@frontend/utils/getRoomHref";
 
 type AllRoomsRoomProps = SearchResponseValue &
   Pick<RoomAvailabilityBoxProps, "roomNumber" | "date">;

--- a/frontend/components/BookingCalendar.tsx
+++ b/frontend/components/BookingCalendar.tsx
@@ -3,6 +3,7 @@
 import "react-big-calendar/lib/css/react-big-calendar.css";
 
 import { Booking } from "@common/types";
+import useBookingCalenderQuery from "@frontend/hooks/useBookingCalenderQuery";
 import NavigateBeforeIcon from "@mui/icons-material/NavigateBefore";
 import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import Box, { BoxProps } from "@mui/material/Box";
@@ -166,14 +167,16 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
   // Enforce day view on mobile
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
-  const [desktopView, setDesktopView] = React.useState<View>(Views.WEEK);
+  const dateTime = useSelector(selectDatetime);
+  const defaultDate = React.useMemo(() => toSydneyTime(dateTime), [dateTime]);
+
+  const [desktopView, date, setDesktopView, setDate] =
+    useBookingCalenderQuery(defaultDate);
+
   const currView = isMobile ? Views.DAY : desktopView;
 
-  const datetime = useSelector(selectDatetime);
-  const [date, setDate] = React.useState<Date>(() => toSydneyTime(datetime));
-
   const handleDateChange = (newDate: Date | null) => {
-    setDate(newDate ?? datetime);
+    setDate(newDate ?? defaultDate);
   };
 
   const calendarMin = React.useMemo(() => {

--- a/frontend/hooks/useBookingCalenderQuery.ts
+++ b/frontend/hooks/useBookingCalenderQuery.ts
@@ -1,0 +1,64 @@
+import { isValidDate } from "@frontend/utils/queryValidation";
+import { format } from "date-fns";
+import { parseAsString, useQueryStates } from "nuqs";
+import { useEffect } from "react";
+import { View, Views } from "react-big-calendar";
+
+const validViewQueries: View[] = [Views.WEEK, Views.DAY];
+
+const isValidView = (view: string): view is View =>
+  validViewQueries.includes(view as View);
+
+const useBookingCalenderQuery = (
+  defaultDate: Date
+): [View, Date, (view: View) => void, (date: Date) => void] => {
+  const [calendarParams, setCalendarParams] = useQueryStates(
+    {
+      view: parseAsString.withDefault(Views.WEEK),
+      date: parseAsString.withDefault(""),
+    },
+    { shallow: true }
+  );
+
+  useEffect(() => {
+    const invalidKeys: { view?: null; date?: null } = {};
+    let hasInvalidParam = false;
+
+    if (calendarParams.view && !isValidView(calendarParams.view)) {
+      invalidKeys.view = null;
+      hasInvalidParam = true;
+    }
+
+    if (calendarParams.date && !isValidDate(calendarParams.date)) {
+      invalidKeys.date = null;
+      hasInvalidParam = true;
+    }
+
+    if (hasInvalidParam) {
+      setCalendarParams(invalidKeys);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const view = isValidView(calendarParams.view)
+    ? calendarParams.view
+    : Views.WEEK;
+
+  const date =
+    calendarParams.date && isValidDate(calendarParams.date)
+      ? new Date(`${calendarParams.date}T00:00:00`)
+      : defaultDate;
+
+  const setView = (nextView: View) => {
+    setCalendarParams({ view: nextView });
+  };
+
+  const setDate = (nextDate: Date) => {
+    setCalendarParams({ date: format(nextDate, "yyy-MM-dd") });
+  };
+
+  return [view, date, setView, setDate];
+};
+
+export default useBookingCalenderQuery;

--- a/frontend/hooks/useDateTimeQuery.ts
+++ b/frontend/hooks/useDateTimeQuery.ts
@@ -1,3 +1,4 @@
+import { isValidDate, isValidTime } from "@frontend/utils/queryValidation";
 import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useRef } from "react";
@@ -5,17 +6,6 @@ import { selectDatetime, setDatetime } from "redux/datetimeSlice";
 
 import { useDispatch, useSelector } from "../redux/hooks";
 import { SYDNEY_TIMEZONE } from "../utils/toSydneyTime";
-
-const isValidDate = (date: string): boolean => {
-  // Valid format is YYYY-MM-DD
-  const newDate = new Date(date);
-  return !isNaN(newDate.getTime());
-};
-
-const isValidTime = (time: string): boolean => {
-  // Valid format is HH:MM (24-hour)
-  return /^([01]\d|2[0-3]):([0-5]\d)$/.test(time);
-};
 
 const useQueryDatetime = () => {
   const dispatch = useDispatch();

--- a/frontend/utils/getRoomHref.ts
+++ b/frontend/utils/getRoomHref.ts
@@ -1,0 +1,11 @@
+import { isValidDate } from "./queryValidation";
+
+const getRoomHref = (roomId: string, date?: string): string => {
+  if (!date || !isValidDate(date)) {
+    return `/room/${roomId}`;
+  }
+
+  return `/room/${roomId}?date=${date}`;
+};
+
+export default getRoomHref;

--- a/frontend/utils/queryValidation.ts
+++ b/frontend/utils/queryValidation.ts
@@ -1,0 +1,20 @@
+export const isValidDate = (date: string): boolean => {
+  // Valid format is YYYY-MM-DD
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return false;
+  }
+
+  const [year, month, day] = date.split("-").map(Number);
+  const parsedDate = new Date(year, month - 1, day);
+
+  return (
+    parsedDate.getFullYear() === year &&
+    parsedDate.getMonth() === month - 1 &&
+    parsedDate.getDate() === day
+  );
+};
+
+export const isValidTime = (time: string): boolean => {
+  // Valid format is HH:MM (24-hour)
+  return /^([01]\d|2[0-3]):([0-5]\d)$/.test(time);
+};

--- a/frontend/views/BuildingDrawer.tsx
+++ b/frontend/views/BuildingDrawer.tsx
@@ -73,6 +73,7 @@ const DirectionsButton = styled(Button)(({ theme }) => ({
 type BuildingDrawerProps = {
   onGetDirections?: (building: Building) => void | Promise<void>;
   isDirectionsLoading?: boolean;
+  date?: string;
 };
 
 const drawerWidth = 400;
@@ -81,6 +82,7 @@ const drawerWidthMobile = "100%";
 const BuildingDrawer: React.FC<BuildingDrawerProps> = ({
   onGetDirections,
   isDirectionsLoading = false,
+  date,
 }) => {
   const dispatch = useDispatch();
   const building = useSelector(selectCurrentBuilding);
@@ -194,6 +196,7 @@ const BuildingDrawer: React.FC<BuildingDrawerProps> = ({
                   roomNumber={roomNumber}
                   roomStatus={rooms.roomStatuses[roomNumber]}
                   buildingId={building.id}
+                  date={date}
                 />
               ))
             ) : (

--- a/frontend/views/RoomAvailabilityBox.tsx
+++ b/frontend/views/RoomAvailabilityBox.tsx
@@ -1,4 +1,5 @@
 import { RoomStatus } from "@common/types";
+import getRoomHref from "@frontend/utils/getRoomHref";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
 import { Typography, TypographyProps } from "@mui/material";
@@ -60,12 +61,14 @@ export interface RoomAvailabilityBoxProps {
   roomNumber: string;
   roomStatus: RoomStatus;
   buildingId: string;
+  date?: string;
 }
 
 const RoomAvailabilityBox: React.FC<RoomAvailabilityBoxProps> = ({
   roomNumber,
   roomStatus,
   buildingId,
+  date,
 }) => {
   const { room } = useRoom(`${buildingId}-${roomNumber}`);
   const { data } = useRoomRatings(room ? room.id : "");
@@ -86,8 +89,10 @@ const RoomAvailabilityBox: React.FC<RoomAvailabilityBoxProps> = ({
       ? photos[0]
       : `/assets/building_photos/${buildingId}.webp`;
 
+  const roomHref = getRoomHref(`${buildingId}-${roomNumber}`, date);
+
   return (
-    <Link href={`/room/${buildingId}-${roomNumber}`}>
+    <Link href={roomHref}>
       <IndiviRoomBox bgImage={`url(${photoURL})`}>
         <Stack direction="column">
           <RoomBoxHeading> {roomNumber} </RoomBoxHeading>


### PR DESCRIPTION
## What

Adds query string support to room pages so the selected calendar date and view can be represented in the URL.

Room links from Browse and All Rooms now preserve the currently selected date.

Examples:

* `/browse?date=2026-09-11&time=18:39`

  * Room link becomes `/room/K-H13-1003?date=2026-09-11`
* `/allRooms?date=2026-09-16&time=18:39`

  * Room link becomes `/room/K-H13-1003?date=2026-09-16`
* `/room/K-H13-1003?date=2026-09-11&view=day`

  * Opens the room calendar on September 11 in Day view

## Why

Selecting a date and then choosing a room would lose the date that was selected.
Sharing a room page for a specific date was impossible, and now you can just share the url.

## How

* Added query string handling for the room booking calendar using `nuqs`.
* Added the queries:

  * `date=YYYY-MM-DD`
  * `view=day`
  * `view=week`
* Added shared query validation for date values.
* Added a shared room URL helper to optionally append a valid date.
* Updated Browse room links to preserve the selected date.
* Updated All Rooms room links to preserve the selected date.
* Invalid date values are not propagated to room URLs.


## Key checks:

* [x] 🚩**Attached screenshot or recording of the changes in related tickets**
* [x] Code comments where needed
* [x] No new warnings

## Automated tests:

* [x] 🚩**Unit tests added**

## Manual tests:

* [x] Big Screen (PC Monitor)
* [x] Small Screen (Laptop monitor)

## Screenshot / Recording

### Selecting a custom date on Browse and opening a room with the same date selected.

https://github.com/user-attachments/assets/2e643ee9-5d43-4638-a157-dfbd960d3940


###  Selecting a custom date on All Rooms and opening a room with the same date selected.

https://github.com/user-attachments/assets/407b197e-6ad6-4a79-a9f4-f55e6fd0c76d


### Changing between Day and Week views on a room page

https://github.com/user-attachments/assets/858d960f-1b0c-40a0-bc4b-994e654bb684



