### PR TITLE
864 - star rating outline now visible in light mode AND UI change to bookings on calendar light mode (misc)

### DIFF
--- a/frontend/__tests__/FavouriteButton.test.tsx
+++ b/frontend/__tests__/FavouriteButton.test.tsx
@@ -7,6 +7,14 @@ import { Provider } from "react-redux";
 
 import Page from "../app/room/[room]/page";
 
+// Mock DarkModeContext to avoid test failing due to importing NuqsAdapter
+jest.mock("../app/clientLayout", () => ({
+  DarkModeContext: require("react").createContext({
+    isDarkMode: false,
+    toggleDarkMode: () => {},
+  }),
+}));
+
 jest.mock("nuqs", () => ({
   useQueryStates: (keys: Record<string, { defaultValue: string }>) => [
     Object.fromEntries(

--- a/frontend/__tests__/RatingStar.test.tsx
+++ b/frontend/__tests__/RatingStar.test.tsx
@@ -13,6 +13,14 @@ import store from "../redux/store";
 import RoomAvailabilityBox from "../views/RoomAvailabilityBox";
 import renderWithRedux from "./utils/renderWithRedux";
 
+// Mock DarkModeContext to avoid test failing due to importing NuqsAdapter
+jest.mock("../app/clientLayout", () => ({
+  DarkModeContext: require("react").createContext({
+    isDarkMode: false,
+    toggleDarkMode: () => {},
+  }),
+}));
+
 jest.mock("nuqs", () => ({
   useQueryStates: (keys: Record<string, { defaultValue: string }>) => [
     Object.fromEntries(

--- a/frontend/app/clientLayout.tsx
+++ b/frontend/app/clientLayout.tsx
@@ -102,7 +102,7 @@ const ClientLayout: React.FC<{
                 },
                 background: {
                   default: "#FFFBF9",
-                  paper: grey[200],
+                  paper: grey[300],
                 },
                 text: {
                   primary: "#000000",

--- a/frontend/components/BookingCalendar.tsx
+++ b/frontend/components/BookingCalendar.tsx
@@ -401,7 +401,7 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
             style: {
               backgroundColor: "#f57c00",
               borderColor: "#f57c00",
-              opacity: theme.palette.mode === "light" ? 1 : 0.8,
+              opacity: 0.8,
             },
           })}
           slotGroupPropGetter={() => ({ style: { minHeight: "50px" } })}

--- a/frontend/components/Rating/ReviewRating.tsx
+++ b/frontend/components/Rating/ReviewRating.tsx
@@ -1,5 +1,6 @@
 import { Rating, Stack, Typography } from "@mui/material";
-import React from "react";
+import { DarkModeContext } from "app/clientLayout";
+import React, { useContext } from "react";
 
 interface ReviewRatingProps {
   category: string;
@@ -10,6 +11,8 @@ const ReviewRating: React.FC<ReviewRatingProps> = ({
   category,
   ratingCallback,
 }) => {
+  const { isDarkMode } = useContext(DarkModeContext);
+
   return (
     <Stack>
       <Typography id="modal-modal-title" variant="body1">
@@ -21,7 +24,9 @@ const ReviewRating: React.FC<ReviewRatingProps> = ({
         onChange={(event, value) => ratingCallback(category, value)}
         size="large"
         sx={{
-          "& .MuiRating-iconEmpty": { color: "#FFFFFF !important" },
+          "& .MuiRating-iconEmpty": {
+            color: `${isDarkMode ? "#FFFFFF" : "#101214"} !important`,
+          },
         }}
       />
     </Stack>


### PR DESCRIPTION
## What

Changes made to the outline colour of star icon in `ReviewRating.tsx`. 
New mock test for DarkModeContext in `FavouriteButton.test.tsx` and `RatingStar.test.tsx`.

Misc: UI change to bookings in calendar on light mode

## Why

Previously, the star rating outline in light mode blended well with the background, making it hard to see where the star was if not hovering. 

Misc: previously, the horizontal lines on the calendar for room bookings were too faint and not visible. Determining when a booking ends or just seeing what time is not clear (opacity). 

## How

Imported DarkModeContext to check whether the current page is on light or dark mode. Then swap the colour of star outline accordingly. 

Misc: set opacity for light mode same as dark mode (0.8) and updated grey to be thicker (200 -> 300) for horizontal line on theme.palette.background.paper. 

## Screenshot / Recording

### Star Rating

**Before**

<img width="360" height="535" alt="image" src="https://github.com/user-attachments/assets/01f7be1a-2511-4fad-b4ac-0fcf8ed3fb3f" />

**After**

<img width="360" height="535" alt="image" src="https://github.com/user-attachments/assets/76792cc1-a43d-4cb9-aacf-0b9e5f31de34" />

### Booking Calendar

**Before**

<img width="1292" height="841" alt="Screenshot From 2026-09-07 16-48-52" src="https://github.com/user-attachments/assets/8e01ab17-81f1-4fbb-99f7-27222f4e13f1" />

**After**

<img width="1292" height="841" alt="Screenshot From 2026-09-07 16-58-43" src="https://github.com/user-attachments/assets/e596535b-6a57-43ac-b5c4-3b6b97550c64" />
