### PR TITLE
874 - ordering of rooms in building drawer

### DIFF
--- a/frontend/views/BuildingDrawer.tsx
+++ b/frontend/views/BuildingDrawer.tsx
@@ -75,6 +75,51 @@ type BuildingDrawerProps = {
   date?: string;
 };
 
+const formatRoomNumber = (room: string): {
+  prefixRank: number;
+  num: number;
+  suffix: string
+} => {
+  const room_order = ['B', 'LG', 'G', 'M'];
+
+  // Regex pattern to match prefix (letter), number, suffix (letter)
+  const match = room.match(/^([A-Za-z]*)(\d+)([A-Za-z]*)$/);
+  if (!match) {
+    return { prefixRank: room_order.length, num: 0, suffix: '' };
+  }
+
+  const prefix = match[1];
+  const num = parseInt(match[2]);
+  const suffix = match[3];
+
+  // Get ordering based on prefix
+  const rankIndex = room_order.indexOf(prefix.toUpperCase());
+
+  return {
+    prefixRank: rankIndex === -1 ? room_order.length : rankIndex,
+    num,
+    suffix,
+  };
+}
+
+const sortRoomNumbers = (rooms: string[]): string[] => {
+  return [...rooms].sort((a, b) => {
+    const sortedA = formatRoomNumber(a);
+    const sortedB = formatRoomNumber(b);
+
+    // Sort by prefix, then by the room number, then by suffix (if provided)
+    if (sortedA.prefixRank !== sortedB.prefixRank) {
+      return sortedA.prefixRank - sortedB.prefixRank;
+    }
+
+    if (sortedA.num !== sortedB.num) {
+      return sortedA.num - sortedB.num;
+    }
+    
+    return sortedA.suffix.localeCompare(sortedB.suffix);
+  });
+}
+
 const drawerWidth = 400;
 const drawerWidthMobile = "100%";
 
@@ -189,7 +234,7 @@ const BuildingDrawer: React.FC<BuildingDrawerProps> = ({
 
           <RoomBox>
             {rooms ? (
-              Object.keys(rooms.roomStatuses).map((roomNumber) => (
+              sortRoomNumbers(Object.keys(rooms.roomStatuses)).map((roomNumber) => (
                 <RoomAvailabilityBox
                   key={roomNumber}
                   roomNumber={roomNumber}


### PR DESCRIPTION
## What

The change now sorts rooms of a building: B -> LG -> G -> M -> numbers...

## Why

When you click on a building in the browse page, the rooms are not in the desired ordering from lowest to highest. E.g. 101, 201, G01.

## How

New arrow function to match each room on a pattern, then ordered based on prefix, number, then suffix (if provided). Priority sorting. 

## Screenshot / Recording

**Before**

<img width="401" height="887" alt="image" src="https://github.com/user-attachments/assets/0d0848ad-16ba-47de-8703-850cd9d9bb13" />

**After**

<img width="401" height="887" alt="image" src="https://github.com/user-attachments/assets/67e21e0f-0087-4892-915b-a5319f13cdc7" />
